### PR TITLE
Updates flaresolverr message

### DIFF
--- a/definitions/v1/7torrents.yml
+++ b/definitions/v1/7torrents.yml
@@ -31,7 +31,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About 7torrents Categories

--- a/definitions/v1/7torrents.yml
+++ b/definitions/v1/7torrents.yml
@@ -31,7 +31,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About 7torrents Categories

--- a/definitions/v1/anirena.yml
+++ b/definitions/v1/anirena.yml
@@ -12,7 +12,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 caps:
   categorymappings:

--- a/definitions/v1/anirena.yml
+++ b/definitions/v1/anirena.yml
@@ -12,7 +12,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 caps:
   categorymappings:

--- a/definitions/v1/btdb.yml
+++ b/definitions/v1/btdb.yml
@@ -52,7 +52,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About BTDB Categories

--- a/definitions/v1/btdb.yml
+++ b/definitions/v1/btdb.yml
@@ -52,7 +52,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About BTDB Categories

--- a/definitions/v1/btschool.yml
+++ b/definitions/v1/btschool.yml
@@ -43,7 +43,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_tpp
     type: info
     label: Results Per Page

--- a/definitions/v1/btschool.yml
+++ b/definitions/v1/btschool.yml
@@ -43,7 +43,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_tpp
     type: info
     label: Results Per Page

--- a/definitions/v1/cpabien.yml
+++ b/definitions/v1/cpabien.yml
@@ -69,7 +69,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About cpasbien Categories

--- a/definitions/v1/cpabien.yml
+++ b/definitions/v1/cpabien.yml
@@ -69,7 +69,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About cpasbien Categories

--- a/definitions/v1/dmhy.yml
+++ b/definitions/v1/dmhy.yml
@@ -45,7 +45,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/dmhy.yml
+++ b/definitions/v1/dmhy.yml
@@ -45,7 +45,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/exttorrents.yml
+++ b/definitions/v1/exttorrents.yml
@@ -90,7 +90,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href^="magnet:?xt="]

--- a/definitions/v1/exttorrents.yml
+++ b/definitions/v1/exttorrents.yml
@@ -90,7 +90,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href^="magnet:?xt="]

--- a/definitions/v1/hddolby.yml
+++ b/definitions/v1/hddolby.yml
@@ -50,7 +50,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_tpp
     type: info
     label: Results Per Page

--- a/definitions/v1/hddolby.yml
+++ b/definitions/v1/hddolby.yml
@@ -50,7 +50,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_tpp
     type: info
     label: Results Per Page

--- a/definitions/v1/idope.yml
+++ b/definitions/v1/idope.yml
@@ -62,7 +62,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/idope.yml
+++ b/definitions/v1/idope.yml
@@ -62,7 +62,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/ilcorsaroblu.yml
+++ b/definitions/v1/ilcorsaroblu.yml
@@ -89,7 +89,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: sort
     type: select
     label: Sort requested from site

--- a/definitions/v1/ilcorsaroblu.yml
+++ b/definitions/v1/ilcorsaroblu.yml
@@ -89,7 +89,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: sort
     type: select
     label: Sort requested from site

--- a/definitions/v1/lastfiles.yml
+++ b/definitions/v1/lastfiles.yml
@@ -83,7 +83,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: sort
     type: select
     label: Sort requested from site

--- a/definitions/v1/lastfiles.yml
+++ b/definitions/v1/lastfiles.yml
@@ -83,7 +83,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: sort
     type: select
     label: Sort requested from site

--- a/definitions/v1/mactorrents.yml
+++ b/definitions/v1/mactorrents.yml
@@ -24,7 +24,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/mactorrents.yml
+++ b/definitions/v1/mactorrents.yml
@@ -24,7 +24,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/montorrent.yml
+++ b/definitions/v1/montorrent.yml
@@ -102,7 +102,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/montorrent.yml
+++ b/definitions/v1/montorrent.yml
@@ -102,7 +102,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/mypornclub.yml
+++ b/definitions/v1/mypornclub.yml
@@ -21,7 +21,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href^="magnet:?xt="]

--- a/definitions/v1/mypornclub.yml
+++ b/definitions/v1/mypornclub.yml
@@ -21,7 +21,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href^="magnet:?xt="]

--- a/definitions/v1/onejav.yml
+++ b/definitions/v1/onejav.yml
@@ -19,7 +19,7 @@ settings:
   - name: flaresolverr-onejav
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.<br><br>If you have issues downloading, perform a keyword search (e.g. <b>video</b>) so FlareSolverr can grab new cookies.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.<br><br>If you have issues downloading, perform a keyword search (e.g. <b>video</b>) so FlareSolverr can grab new cookies.
 
 search:
   paths:

--- a/definitions/v1/onejav.yml
+++ b/definitions/v1/onejav.yml
@@ -19,7 +19,7 @@ settings:
   - name: flaresolverr-onejav
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.<br><br>If you have issues downloading, perform a keyword search (e.g. <b>video</b>) so FlareSolverr can grab new cookies.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.<br><br>If you have issues downloading, perform a keyword search (e.g. <b>video</b>) so FlareSolverr can grab new cookies.
 
 search:
   paths:

--- a/definitions/v1/pirateiro.yml
+++ b/definitions/v1/pirateiro.yml
@@ -56,7 +56,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/pirateiro.yml
+++ b/definitions/v1/pirateiro.yml
@@ -56,7 +56,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   paths:

--- a/definitions/v1/prostylex.yml
+++ b/definitions/v1/prostylex.yml
@@ -108,7 +108,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 login:
   path: account-login.php

--- a/definitions/v1/prostylex.yml
+++ b/definitions/v1/prostylex.yml
@@ -108,7 +108,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 login:
   path: account-login.php

--- a/definitions/v1/skytorrents-to.yml
+++ b/definitions/v1/skytorrents-to.yml
@@ -53,7 +53,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   # https://skytorrents.to/?search=mr+mercedes+s02e05&sort=created

--- a/definitions/v1/skytorrents-to.yml
+++ b/definitions/v1/skytorrents-to.yml
@@ -53,7 +53,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 search:
   # https://skytorrents.to/?search=mr+mercedes+s02e05&sort=created

--- a/definitions/v1/torrent9clone.yml
+++ b/definitions/v1/torrent9clone.yml
@@ -78,7 +78,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: multilang
     type: checkbox
     label: Replace MULTI by another language in release name

--- a/definitions/v1/torrent9clone.yml
+++ b/definitions/v1/torrent9clone.yml
@@ -78,7 +78,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: multilang
     type: checkbox
     label: Replace MULTI by another language in release name

--- a/definitions/v1/torrentkitty.yml
+++ b/definitions/v1/torrentkitty.yml
@@ -25,7 +25,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About TorrentKitty Categories

--- a/definitions/v1/torrentkitty.yml
+++ b/definitions/v1/torrentkitty.yml
@@ -25,7 +25,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: info_8000
     type: info
     label: About TorrentKitty Categories

--- a/definitions/v1/torrentmax.yml
+++ b/definitions/v1/torrentmax.yml
@@ -42,7 +42,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href*="magnet:?xt="]

--- a/definitions/v1/torrentmax.yml
+++ b/definitions/v1/torrentmax.yml
@@ -42,7 +42,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href*="magnet:?xt="]

--- a/definitions/v1/torrentqq.yml
+++ b/definitions/v1/torrentqq.yml
@@ -47,7 +47,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: downloads
     type: info
     label: About Downloads

--- a/definitions/v1/torrentqq.yml
+++ b/definitions/v1/torrentqq.yml
@@ -47,7 +47,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
   - name: downloads
     type: info
     label: About Downloads

--- a/definitions/v1/torrentsir.yml
+++ b/definitions/v1/torrentsir.yml
@@ -35,7 +35,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href*="magnet:?xt="]

--- a/definitions/v1/torrentsir.yml
+++ b/definitions/v1/torrentsir.yml
@@ -35,7 +35,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href*="magnet:?xt="]

--- a/definitions/v1/torrentwhiz.yml
+++ b/definitions/v1/torrentwhiz.yml
@@ -34,7 +34,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href*="magnet:?xt="]

--- a/definitions/v1/torrentwhiz.yml
+++ b/definitions/v1/torrentwhiz.yml
@@ -34,7 +34,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 download:
   selector: a[href*="magnet:?xt="]

--- a/definitions/v1/yggcookie.yml
+++ b/definitions/v1/yggcookie.yml
@@ -178,7 +178,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 login:
   method: cookie

--- a/definitions/v1/yggcookie.yml
+++ b/definitions/v1/yggcookie.yml
@@ -178,7 +178,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 login:
   method: cookie

--- a/definitions/v1/yggtorrent.yml
+++ b/definitions/v1/yggtorrent.yml
@@ -169,7 +169,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 login:
   method: form

--- a/definitions/v1/yggtorrent.yml
+++ b/definitions/v1/yggtorrent.yml
@@ -169,7 +169,7 @@ settings:
   - name: flaresolverr
     type: info
     label: FlareSolverr
-    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
+    default: This site may use Cloudflare DDoS Protection, currently Prowlarr doesn't support Flaresolverr, see here <a href="https://wikijs.servarr.com/en/prowlarr/faq#can-i-use-flaresolverr-indexers" target="_blank">here</a> for more details.
 
 login:
   method: form


### PR DESCRIPTION
Updates the Flaresolverr message to better describe the current circumstances of using Indexers that have CloudFlare protection
As currently, it talks about it as if it was Jackett, as these were copied from the Jackett files
This change helps point users to the Prowlarr wiki where it explains the situation in more detail

This is piggybacking off the discussion within the Discord, see [here](https://canary.discord.com/channels/767843854736949299/767843854824374281/851193657121701958)