### PR TITLE
hotfix - revert 1337x option removals [revert me]

### DIFF
--- a/definitions/v1/1337x.yml
+++ b/definitions/v1/1337x.yml
@@ -144,7 +144,7 @@ settings:
   - name: downloadlink
     type: select
     label: Download link
-    default: "default: "magnet:"
+    default: "magnet:"
     options:
       "http://itorrents.org/": iTorrents.org
       "http://torrage.info/": Torrage

--- a/definitions/v1/1337x.yml
+++ b/definitions/v1/1337x.yml
@@ -144,16 +144,20 @@ settings:
   - name: downloadlink
     type: select
     label: Download link
-    default: "http://itorrents.org/"
+    default: "default: "magnet:"
     options:
       "http://itorrents.org/": iTorrents.org
+      "http://torrage.info/": Torrage
+      "http://btcache.me/": BTcache
       "magnet:": magnet
   - name: downloadlink2
     type: select
     label: Download link (fallback)
-    default: "magnet:"
+    default: "http://itorrents.org/"
     options:
       "http://itorrents.org/": iTorrents.org
+      "http://torrage.info/": Torrage
+      "http://btcache.me/": BTcache
       "magnet:": magnet
   - name: info_download
     type: info


### PR DESCRIPTION
revert the optional removals in https://github.com/Prowlarr/Indexers/commit/62cb46cf32cd3472495c7bb8f62582cb6df4d9fe as Prowlarr (incorrectly) stores the index and not the key value