### PR TITLE
Fix: (Indexers) (Abnormal) Fix indexer not returning download url #91

### DIFF
--- a/definitions/v2/abnormal.yml
+++ b/definitions/v2/abnormal.yml
@@ -104,7 +104,7 @@ search:
     title:
       text: "{{ if .Config.subfrench }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     download:
-      selector: td:nth-child(4) > a
+      selector: a[href^="/Torrent/Download?ReleaseId="]
       attribute: href
     details:
       selector: a[href^="/Torrent/Details?ReleaseId="]


### PR DESCRIPTION
- Changing scrap of download url to avoid problems if ABN changes its tr again

This will fix https://github.com/Prowlarr/Indexers/issues/91 and prevent some issue later
Trying to avoid "td:nth-child" so we're not depending on the layout of the Torrent page but still 3 fields can't be scrap without it : 
- size
- seeders
- leechers

I will try to contact them to add classes to that, but for now, this will do the trick