### PR TITLE
fix: login at bittorrentfiles (#666)

### DIFF
--- a/definitions/v2/Bittorrentfiles.yml
+++ b/definitions/v2/Bittorrentfiles.yml
@@ -131,11 +131,11 @@ settings:
 
 login:
   path: signin.php
-  method: form
-  form: form
+  method: post
   inputs:
     user: "{{ .Config.user }}"
     pass: "{{ .Config.pass }}"
+    returnto: "%2Fbrowse.php"
   error:
     - selector: .error
   test:


### PR DESCRIPTION
I am not sure why, but it fixes the login. Tested by search in prowlarr afterwards - works.

closes https://github.com/Prowlarr/Prowlarr/issues/666