### PR TITLE
fix: add user-agent for soundpark

### DIFF
--- a/definitions/v2/soundpark.yml
+++ b/definitions/v2/soundpark.yml
@@ -25,6 +25,13 @@ settings:
     type: info
     label: How to get the Cookie
     default: "<ol><li>Login to this tracker with your browser<li>Open the <b>DevTools</b> panel by pressing <b>F12</b><li>Select the <b>Network</b> tab<li>Click on the <b>Doc</b> button (Chrome Browser) or <b>HTML</b> button (FireFox)<li>Refresh the page by pressing <b>F5</b><li>Click on the first row entry<li>Select the <b>Headers</b> tab on the Right panel<li>Find <b>'cookie:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole cookie string <i>(everything after 'cookie: ')</i> and <b>Paste</b> here.</ol>"
+  - name: useragent
+    type: text
+    label: User-Agent
+  - name: info_useragent
+    type: info
+    label: How to get the User-Agent
+    default: "<ol><li>From the same place you fetched the cookie,<li>Find <b>'user-agent:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole user-agent string <i>(everything after 'user-agent: ')</i> and <b>Paste</b> here.</ol>"
 
 login:
   method: cookie
@@ -44,6 +51,9 @@ download:
       usebeforeresponse: true
 
 search:
+  headers:
+      User-Agent: ["{{ .Config.useragent }}"]
+
   paths:
     # https://sound-park.world/filter/?sort_method=1&sorting_type=undefined&genres=&qualities=&country_keyword=&countries=&releases=&start_year=&end_year=&search_keyword=
     - path: filter/


### PR DESCRIPTION
SoundPark requires user-agent in addition to cookie, else the cloudflare authorization fails.