### PR TITLE
Fixed indexers returning an error due to domain redirects

### DIFF
--- a/definitions/v3/torrentleech.yml
+++ b/definitions/v3/torrentleech.yml
@@ -7,10 +7,10 @@ type: private
 encoding: UTF-8
 links:
   - https://www.torrentleech.org/
-  - https://torrentleech.cc/
-  - https://torrentleech.me/
-  - https://tleechreload.org/
-  - https://tlgetin.cc/
+  - https://www.torrentleech.cc/
+  - https://www.torrentleech.me/
+  - https://www.tleechreload.org/
+  - https://www.tlgetin.cc/
 legacylinks:
   - https://v4.torrentleech.org/
 


### PR DESCRIPTION
Logs are showing domains are redirecting to the www variant which causes indexer issues.