### PR TITLE
indexer(hdonly): v5 with enhancements

### DIFF
--- a/definitions/v5/hdonly.yml
+++ b/definitions/v5/hdonly.yml
@@ -177,9 +177,6 @@ search:
     title_group:
       selector: div.group_info.clear > div.torrent_info > strong:last-child
       attribute: title
-      filters:
-        - name: strdump
-          args: rlsgroup
     # title > step 4 - grab release infos and normalize
     title_infos:
       selector: div.group_info.clear > div.torrent_info
@@ -223,9 +220,6 @@ search:
     # title > step 5 - finale concatenation
     title:
       text: "{{ .Result.title_result }}{{ .Result.title_year }}{{ .Result.title_infos }}{{ if .Result.title_group }}-{{ .Result.title_group }}{{ else }}-HDO{{ end }}"
-      filters:
-        - name: strdump
-          args: normalized
     ### NEXT
     description:
       selector: div.group_info

--- a/definitions/v5/hdonly.yml
+++ b/definitions/v5/hdonly.yml
@@ -1,0 +1,299 @@
+---
+id: hdonly
+name: HD-Only
+description: "HD-Only (HD-O) is a FRENCH Private Torrent Tracker for HD MOVIES / TV"
+language: fr-FR
+type: private
+encoding: UTF-8
+followredirect: false
+allowdownloadredirect: false
+protocol: torrent
+testlinktorrent: true
+links:
+  - https://hd-only.org/
+
+caps:
+  categorymappings:
+    - {id: 1, cat: Movies, desc: "Film", default: true}
+    - {id: 3, cat: TV/Anime, desc: "Dessin animé"}
+    - {id: 5, cat: TV, desc: "Série"}
+    - {id: 6, cat: TV/Anime, desc: "Série animé"}
+    - {id: 7, cat: Movies/Other, desc: "Film d'animation"}
+    - {id: 9, cat: Audio/Video, desc: "Concert"}
+    - {id: 11, cat: TV/Documentary, desc: "Documentaire"}
+    - {id: 13, cat: Movies/Other, desc: "Court-métrage"}
+    - {id: 14, cat: Movies/Other, desc: "Clip"}
+    - {id: 15, cat: Movies/Other, desc: "Démonstration"}
+    - {id: 16, cat: Movies/Other, desc: "Bonus de BD"}
+    - {id: 21, cat: Other, desc: "Autre"}
+
+  modes:
+    search: [q]
+    tv-search: [q]
+    movie-search: [q]
+
+settings:
+  - name: username
+    type: text
+    label: Username
+  - name: password
+    type: password
+    label: Password
+  - name: info_search
+    type: info
+    label: Search Tweak
+    default: You can tweak the search query by using the following parameters.
+  - name: scene
+    type: checkbox
+    label: Scene Release only
+    default: false
+  - name: bitrate
+    type: select
+    label: Bitrate
+    default: all
+    options:
+      all: all
+      4320p: 4320p
+      2160p: 2160p
+      1440p: 1440p
+      1080p: 1080p
+      1080i: 1080i
+      720p: 720p
+  - name: format
+    type: select
+    label: Format
+    default: all
+    options:
+      all: all
+      x264: x264
+      VC-1: VC-1
+      AVC: AVC
+      MPEG-2: MPEG-2
+      x265: x265
+      HEVC: HEVC
+      VP9: VP9
+      Autre: others
+  - name: sort
+    type: select
+    label: Sort by
+    default: time
+    options:
+      time: created
+      year: year
+      size: size
+      snatched: snatched
+      seeders: seeders
+      leechers: leechers
+      random: random
+  - name: type
+    type: select
+    label: Order type
+    default: desc
+    options:
+      desc: descendant
+      asc: ascendant
+  - name: freeleech
+    type: checkbox
+    label: Freeleech only
+    default: false
+  - name: info_replacement
+    type: info
+    label: Replacements
+    default: You can replace some values by using the following parameters.
+  - name: multilang
+    type: checkbox
+    label: Replace MULTI in release name
+    default: false
+  - name: multilanguage
+    type: select
+    label: ... by this language
+    default: FRENCH
+    options:
+      FRENCH: FRENCH
+      MULTI.FRENCH: MULTI.FRENCH
+      ENGLISH: ENGLISH
+      MULTI.ENGLISH: MULTI.ENGLISH
+      VOSTFR: VOSTFR
+      MULTI.VOSTFR: MULTI.VOSTFR
+  - name: vostfr
+    type: checkbox
+    label: Replace VOSTFR with ENGLISH
+    default: false
+
+login:
+  path: login.php
+  method: post
+  inputs:
+    username: "{{ .Config.username }}"
+    password: "{{ .Config.password }}"
+    keeplogged: 1
+  error:
+    - selector: form#loginform > span.warning
+  test:
+    path: torrents.php
+    selector: a[href^="logout.php?auth="]
+
+search:
+  path: torrents.php
+  inputs:
+    searchstr: "{{ .Keywords }}"
+    order_by: "{{ .Config.sort }}"
+    order_way: "{{ .Config.type }}"
+    group_results: 0
+    encoding: "{{ if ne .Config.bitrate \"all\" }}{{ .Config.bitrate }}{{ else }}{{ end }}"
+    format: "{{ if ne .Config.format \"all\" }}{{ .Config.format }}{{ else }}{{ end }}"
+    freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
+    scene: "{{ if .Config.scene }}1{{ else }}0{{ end }}"
+    action: advanced
+    searchsubmit: 1
+
+  rows:
+    selector: table#torrent_table > tbody > tr.torrent
+
+  fields:
+    download:
+      selector: a[href^="torrents.php?action=download&"]
+      attribute: href
+    # title > step 1 - grab orginal title and normalize
+    title_result:
+      selector: div.group_info > a
+      filters:
+        - name: trim
+        - name: re_replace
+          args: ["\\s:\\s", " "]
+        - name: re_replace
+          args: ["\\s", "."]
+        - name: append
+          args: "."
+    # title > step 2 - grab movie year
+    title_year:
+      selector: div.group_info.clear
+      filters:
+        - name: regexp
+          args: "\\s\\[(\\d{4})\\]\\s"
+        - name: append
+          args: "."
+    # title > step 3 - grab release group
+    title_group:
+      selector: div.group_info.clear > div.torrent_info > strong:last-child
+      attribute: title
+      filters:
+        - name: strdump
+          args: rlsgroup
+    # title > step 4 - grab release infos and normalize
+    title_infos:
+      selector: div.group_info.clear > div.torrent_info
+      remove: strong
+      filters:
+        - name: toupper
+        - name: re_replace
+          args: ["\\sBLU-RAY\\s(ORIGINAL|4K|HD)\\s", "COMPLETE.BLURAY"]
+        - name: re_replace
+          args: ["\\sBLU-RAY\\sREMUX\\s(4K|HD)\\s", "BLURAY.REMUX"]
+        - name: re_replace
+          args: ["\\sBLU-RAY\\sRIP\\s(4K|HD)\\s", "BLURAY"]
+        - name: re_replace
+          args: ["\\sWEB-DL/RIP\\s(4K|HD)\\s", "WEBDL"]
+        - name: re_replace
+          args: ["\\s(CUST_SUB|CUST|CRIT|WAC|MOC|BFI|MUET|EXC\\sNF|EXC\\sAMZ|EXC\\sYOU)\\s", ""]
+        - name: re_replace
+          args: ["\\s(VOF|STFR)\\s", ""]
+        - name: re_replace
+          args: ["\\sVO\\s", "MULTI"]
+        - name: re_replace
+          args: ["\\s(UN)\\s", "UNRATED"]
+        - name: re_replace
+          args: ["\\s(ES)\\s", "SPECIAL.EDITION"]
+        - name: re_replace
+          args: ["\\s(UC)\\s", "UNCUT"]
+        - name: re_replace
+          args: ["\\s(RM)\\s", "REMASTERED"]
+        - name: re_replace
+          args: ["\\s(VL)\\s", "EXTENDED"]
+        - name: re_replace
+          args: ["\\s(DC)\\s", "DIRECTORS.CUT"]
+        - name: re_replace
+          args: ["\\s+", ""]
+        - name: re_replace
+          args: ["\/+", "."]
+        - name: trim
+          args: "."
+        - name: re_replace
+          args: ["VFF.VFQ", "VFF"]
+    # title > step 5 - finale concatenation
+    title:
+      text: "{{ .Result.title_result }}{{ .Result.title_year }}{{ .Result.title_infos }}{{ if .Result.title_group }}-{{ .Result.title_group }}{{ else }}-HDO{{ end }}"
+      filters:
+        - name: strdump
+          args: normalized
+    ### NEXT
+    description:
+      selector: div.group_info
+    poster:
+      selector: div.group_image img
+      attribute: src
+    details:
+      selector: a[href^="torrents.php?id="]
+      attribute: href
+    files:
+      selector: td:nth-child(3)
+    date:
+      selector: td:nth-child(4)
+      filters:
+        - name: replace
+          args: ["heures", "hours"]
+        - name: replace
+          args: ["heure", "hour"]
+        - name: replace
+          args: ["jours", "days"]
+        - name: replace
+          args: ["jour", "day"]
+        - name: replace
+          args: ["semaines", "weeks"]
+        - name: replace
+          args: ["semaine", "week"]
+        - name: replace
+          args: ["mois", "months"]
+        - name: replace
+          args: ["ans", "years"]
+        - name: replace
+          args: ["an", "year"]
+        - name: append
+          args: " ago"
+    size:
+      selector: td:nth-child(5)
+    grabs:
+      selector: td:nth-child(6)
+    seeders:
+      selector: td:nth-child(7)
+    leechers:
+      selector: td:nth-child(8)
+    downloadvolumefactor:
+      case:
+        "div.group_info:contains(\"/ Freeleech!\")": 0
+        "*": 1
+    uploadvolumefactor:
+      text: 1
+    category:
+      selector: div.group_info
+      remove: span, div, a
+      case:
+        ":contains(\"[Film]\")": 1
+        ":contains(\"[Dessin animé]\")": 3
+        ":contains(\"[Série]\")": 5
+        ":contains(\"[Série Animée]\")": 6
+        ":contains(\"[Film d'animation]\")": 7
+        ":contains(\"[Concert]\")": 9
+        ":contains(\"[Documentaire]\")": 11
+        ":contains(\"[Court-métrage]\")": 13
+        ":contains(\"[Clip]\")": 14
+        ":contains(\"[Démonstration]\")": 15
+        ":contains(\"[Bonus de BD]\")": 16
+        ":contains(\"[Autre]\")": 21
+        "*": 5
+    minimumratio:
+      text: 1.0
+    minimumseedtime:
+      # 3 days (as seconds = 3 x 24 x 60 x 60)
+      text: 259200
+# Gazelle


### PR DESCRIPTION
Revision of HDONLY tracker definition.

- definition: version 5
- mapping: corrected (#132) + typo
- settings: added scene filter
- settings: added bitrate filter
- settings: added format filter
- settings: added more options to sort filter
- settings: removed year info for radarr
- search: replaced groupename with searchstr, now works with year (#132)
- search: added more filters
- results: re-worked completely title formatting, normalization and logic
- results: now compatible with [trash guides](https://trash-guides.info/), no more wrong scoring due to release group not correclty identified