### PR TITLE
Transform MEGAPACK and AUDIOEDITADO tags to PROPER

### DIFF
--- a/definitions/v2/hdspain.yml
+++ b/definitions/v2/hdspain.yml
@@ -79,6 +79,10 @@ search:
           args: "["
         - name: append
           args: "]"
+        - name: re_replace
+          args: ["(?i)(MEGAPACK)", "PROPER"]
+        - name: re_replace
+          args: ["(?i)(AUDIOEDITADO)", "PROPER"]
     title_vose:
       selector: td.titulo a[id]:contains("VOSE")
       optional: true


### PR DESCRIPTION
Convert some tags to better manage of PROPER edited files, and packs with multiple files.