### PR TITLE
Updating YggTorrent with new domain

### DIFF
--- a/definitions/v3/yggcookie.yml
+++ b/definitions/v3/yggcookie.yml
@@ -7,8 +7,9 @@ type: semi-private
 encoding: UTF-8
 followredirect: true
 links:
-  - https://www3.yggtorrent.re/
+  - https://www.yggtorrent.la/
 legacylinks:
+  - https://www3.yggtorrent.re/
   - https://yggtorrent.com/
   - https://ww1.yggtorrent.com/
   - https://yggtorrent.is/

--- a/definitions/v3/yggtorrent.yml
+++ b/definitions/v3/yggtorrent.yml
@@ -7,8 +7,9 @@ type: semi-private
 encoding: UTF-8
 followredirect: true
 links:
-  - https://www3.yggtorrent.re/
+  - https://www.yggtorrent.la/
 legacylinks:
+  - https://www3.yggtorrent.re/
   - https://yggtorrent.com/
   - https://ww1.yggtorrent.com/
   - https://yggtorrent.is/


### PR DESCRIPTION
Domain changed from https://www3.yggtorrent.re to https://yggtorrent.la/