### PR TITLE
ygg replace slash with space for search

### DIFF
--- a/definitions/v3/yggcookie.yml
+++ b/definitions/v3/yggcookie.yml
@@ -215,6 +215,9 @@ search:
      # Replace - with space due to internal YGG Issues
     - name: replace
       args: ["-", " "]
+     # Replace / with space due to internal YGG Issues
+    - name: replace
+      args: ["/", " "]
     - name: replace
       args: ["  ", " "]
     - name: trim

--- a/definitions/v3/yggtorrent.yml
+++ b/definitions/v3/yggtorrent.yml
@@ -225,6 +225,9 @@ search:
      # Replace - with space due to internal YGG Issues
     - name: replace
       args: ["-", " "]
+     # Replace / with space due to internal YGG Issues
+    - name: replace
+      args: ["/", " "]
     - name: replace
       args: ["  ", " "]
     - name: trim


### PR DESCRIPTION
Searching for a movie with a / in the title confuses the ygg search engine. Replacing it with a space fixes the problem.