### PR TITLE
Update yts.yml

### DIFF
--- a/definitions/v5/yts.yml
+++ b/definitions/v5/yts.yml
@@ -92,7 +92,7 @@ search:
           args: [" ", "."]
         # append type: BRRip or WEBRip, resolves #3558 via #4577
         - name: append
-          args: ".{{ .Result.year }}.{{ .Result._quality }}.{{ if eq .Result._type \"web\" }}WEBRip{{ else }}BRRip{{ end }}-YTS"
+          args: ".{{ .Result._year }}.{{ .Result._quality }}.{{ if eq .Result._type \"web\" }}WEBRip{{ else }}BRRip{{ end }}-YTS"
     _sitelink_trimmed:
       text: "{{ .Config.sitelink }}"
       filters:


### PR DESCRIPTION
Updating the arg under title selector to match the year selector. Currently this typo is preventing successful indexer validation. Confirmed the change resolves the issue

"Result.year" => "Result._year"

#### Indexer/Tracker


#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Issues Fixed or Closed by this PR

* Fixes #XXXX