### PR TITLE
revert validation fail to ne 0

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -17,12 +17,12 @@ for dir in $(find definitions -type d -name "v*"); do
 
     ajv test -d "$dir/*.yml" -s "$schema" --valid --all-errors -c ajv-formats
 
-    if [ "$?" -eq 1 ]; then
+    if [ "$?" -ne 0 ]; then
         fail=1
     fi
 done
 
-if [ "$fail" -eq 1 ]; then
+if [ "$fail" -ne 0 ]; then
     echo "Failed"
     exit 1
 fi


### PR DESCRIPTION
#### Indexer/Tracker
N/A

#### Description
Issue discovered in https://github.com/Jackett/Jackett/pull/13490/commits/77683cf68483e05aeb9f0e4e06f59891d58fbf00 where when using `eq 1` for validation fail, adding a leading space to the attribute breaks the validation completely, and results in the error `Invalid left-hand side expression in prefix operation`, but the validation is still deemed successful - https://dev.azure.com/Jackett/Jackett/_build/results?buildId=6559&view=logs&j=9f2a564b-74e8-5c98-938f-029d53ac7443&t=19445350-200f-5747-7911-92f66750f853

This PR resolves the false negative failure issue.

This PR does **not** resolve the issue of a single leading space breaking the validation.


#### Issues Fixed or Closed by this PR

N/A