### PR TITLE
Fix Lat-Team Definition to find TV Shows

### DIFF
--- a/definitions/v7/lat-team-api.yml
+++ b/definitions/v7/lat-team-api.yml
@@ -15,20 +15,16 @@ caps:
     - {id: 3, cat: Audio, desc: "Musica"}
     - {id: 4, cat: Console, desc: "Juegos"}
     - {id: 5, cat: TV/Anime, desc: "Anime"}
-    - {id: 6, cat: Movies/Other, desc: "Retro Pelicula"}
-    - {id: 7, cat: TV/Other, desc: "Retro Serie TV"}
-    - {id: 8, cat: TV/Foreign, desc: "Telenovelas y Teleseries"}
+    - {id: 8, cat: TV/Foreign, desc: "Telenovelas"}
     - {id: 9, cat: Audio/Video, desc: "Conciertos"}
-    - {id: 10, cat: TV/Documentary, desc: "Documentales"}
-    - {id: 11, cat: Other, desc: "Videotutoriales y Educativo"}
+    - {id: 11, cat: Audio/Audiobook, desc: "Audiolibros"}
     - {id: 12, cat: XXX, desc: "XXX"}
-    - {id: 16, cat: TV/Sport, desc: "Deportes"}
-    - {id: 17, cat: PC, desc: "Sistemas Operativos"}
+    - {id: 16, cat: TV/Sport, desc: "Eventos Deportivos"}
+    - {id: 17, cat: PC, desc: "Software & O.S."}
     - {id: 18, cat: Books, desc: "E-Books"}
-    - {id: 19, cat: Audio/Audiobook, desc: "Audiolibros"}
-    - {id: 20, cat: Movies/Other, desc: "Películas Oscars"}
-    - {id: 21, cat: Audio/Video, desc: "VideoMixes"}
+    - {id: 20, cat: TV/Foreign, desc: "Doramas & Turcas"}
     - {id: 22, cat: TV/Other, desc: "Playlist_Collection"}
+    - {id: 24, cat: Other, desc: "Cursos"}
 
   modes:
     search: [q]
@@ -97,8 +93,6 @@ search:
   keywordsfilters:
     - name: re_replace
       args: ["\\.", " "]
-    - name: re_replace
-      args: ["(?i)\\bS(\\d+)", "T$1"]
 
   rows:
     selector: data
@@ -113,24 +107,12 @@ search:
       selector: name:contains(VOSE)
       optional: true
       filters:
-        - name: re_replace
-          args: ["^ *\\[[^\\]]*\\] *", ""] # Remove prefix tags
-        - name: re_replace
-          args: ["(?i)\\bT(\\d+)", "S$1"]
-        - name: re_replace
-          args: ["UHDRip", "BDRip"] # Fix for Radarr
         - name: append
           args: " ENGLiSH"
     title_notvose:
       selector: name:not(:contains(VOSE))
       optional: true
       filters:
-        - name: re_replace
-          args: ["^ *\\[[^\\]]*\\] *", ""] # Remove prefix tags
-        - name: re_replace
-          args: ["(?i)\\bT(\\d+)", "S$1"]
-        - name: re_replace
-          args: ["UHDRip", "BDRip"] # Fix for Radarr
         - name: append
           args: " SPANiSH"
     title:
@@ -142,7 +124,7 @@ search:
     infohash:
       selector: info_hash
     poster:
-      selector: poster
+      selector: meta.poster
       filters:
         - name: replace
           args: ["https://via.placeholder.com/90x135", ""]
@@ -181,9 +163,7 @@ search:
       case:
         0: 1 # normal
         1: 2 # double
-    minimumratio:
-      text: 1.0
     minimumseedtime:
-      # 4 days (as seconds = 4 x 24 x 60 x 60)
-      text: 345600
-# json UNIT3D 6.3.0
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
+# json UNIT3D 6.4.0b

--- a/definitions/v7/lat-team-api.yml
+++ b/definitions/v7/lat-team-api.yml
@@ -163,7 +163,10 @@ search:
       case:
         0: 1 # normal
         1: 2 # double
+# global MR is 0.4 but torrents must be seeded for 7 days regardless of ratio
+#    minimumratio:
+#      text: 0.4
     minimumseedtime:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800
-# json UNIT3D 6.4.0b
+# json UNIT3D 6.4.1


### PR DESCRIPTION
Previously, looking the S01E01 part of a query would get changed to T01E01 which made it impossible to find TV shows from the tracker.

#### Indexer/Tracker
Lat-Team

#### Description
Previously, the S01E01 part of a query would get changed to T01E01 which made it impossible to find TV shows from the tracker.

Searching for Generic Show S01E01 resulted in a API query that included Generic Show T01E01. Consequently, Jackett was not finding any TV show from the tracker.

I tested it locally and now it works as intended.

Other changes include:
- The tracker categories have been updated.
- Update the minimum seeding time according to the tracker rules
- Remove minimum ratio as the minimum seeding time is mandatory despite of ratio

#### Issues Fixed or Closed by this PR

These issues had not been reported previously