### PR TITLE
fix(arenabg): fix torrent title selector

### DIFF
--- a/definitions/v7/arenabg.yml
+++ b/definitions/v7/arenabg.yml
@@ -160,18 +160,18 @@ search:
       attribute: title
       optional: true
     title:
-      selector: td.filename a[href^="/en/torrents/"]
+      selector: &title-selector td.filename a.title
       filters:
         - name: append
           args: "{{ if .Result._bulgarian }} {{ .Result._bulgarian }}{{ else }}{{ end }}{{ if .Result._english }} {{ .Result._english }}{{ else }}{{ end }}"
     details:
-      selector: td.filename a[href^="/en/torrents/"]
+      selector: *title-selector
       attribute: href
     download:
-      selector: td.filename a[href^="/en/torrents/"]
+      selector: *title-selector
       attribute: href
     poster:
-      selector: td.filename a[href^="/en/torrents/"]
+      selector: *title-selector
       attribute: onmouseover
       filters:
         - name: regexp


### PR DESCRIPTION
#### Indexer/Tracker
ArenaBG

#### Description
This PR resolves an issue with the ArenaBG title selector, which arises when searching for your own torrents.

If a torrent you've uploaded is included in the query, there's an "edit" button next to the title, which looks like this:
![image](https://user-images.githubusercontent.com/38114607/200614227-5e7e27b7-d75a-4b9e-b9f3-d803bf1b04de.png)

The existing selector looks for the first `a` tag with an `href` beginning with `/en/torrents/`, which isn't correct in this case, since the "edit" link's `href` also begins with `/en/torrents/`.

The selector included in this PR uses the "title" class on the title `a` element instead, which proves to be reliable in the few tests I ran, both including torrents I've uploaded and not.

#### Issues Fixed or Closed by this PR

N/A