### PR TITLE
Fix Aither titles

### DIFF
--- a/definitions/v7/aither-api.yml
+++ b/definitions/v7/aither-api.yml
@@ -100,6 +100,14 @@ search:
       selector: category_id
     title:
       selector: name
+      filters:
+        # https://regex101.com/r/gPP7Y8/1
+        # Aither requires English titles, aliases or the original title
+        # are separated by an "AKA"
+        # input: Example AKA Beispiel Year Resolution Source AudioCodec Channels ColorDepth VideoCodec-Crew
+        - name: regexp
+          args: "^.*\\bAKA\\b(.+)"
+        # result: Beispiel Year Resolution Source AudioCodec Channels ColorDepth VideoCodec-Crew
     details:
       selector: details_link
     download:


### PR DESCRIPTION
#### Indexer/Tracker

Aither.cc

#### Description

Aither requires English titles and original titles and aliases have to be separated with an “AKA”:

```
Example AKA Beispiel Year Resolution Source AudioCodec Channels ColorDepth VideoCodec-Crew
```

This breaks applications because they will parse the title as “Example AKA Beispiel” when in reality it should be either “Example” or “Beispiel”. I don't know if this _should_ be fixed here or somewhere else. Also, the regex I used is case-sensitive, I don't know if Prowlarr cares about this or not.

#### Issues Fixed or Closed by this PR

None
