### PR TITLE
yggtorrent: fix episode re_replace

### DIFF
--- a/definitions/v7/yggcookie.yml
+++ b/definitions/v7/yggcookie.yml
@@ -216,7 +216,7 @@ search:
     - name: re_replace # episode number at the end "1234" to "E1234"
       args: ["(.*)(\\.|\\s|\\-)(\\d{4})(\\.|\\s|\\-*)(.*)", "{{ if .Config.enhancedAnime4 }}$1 E$3 $5{{ else }}$1$2$3$4$5{{ end }}"]
     - name: re_replace # episode number at the end "123" to "E123"
-      args: ["(.*)(\\.|\\s|\\-)(\\d{2,4})(\\.|\\s|\\-*)(.*)", "{{ if .Config.enhancedAnime }}$1 E$3 $5{{ else }}$1$2$3$4$5{{ end }}"]
+      args: ["(.*)(\\.|\\s|\\-)(\\d{2,3})(\\.|\\s|\\-*)(.*)", "{{ if .Config.enhancedAnime }}$1 E$3 $5{{ else }}$1$2$3$4$5{{ end }}"]
     # END ANIME HACK
     - name: replace
       args: ["\"", ""]

--- a/definitions/v7/yggtorrent.yml
+++ b/definitions/v7/yggtorrent.yml
@@ -226,7 +226,7 @@ search:
     - name: re_replace # episode number at the end "1234" to "E1234"
       args: ["(.*)(\\.|\\s|\\-)(\\d{4})(\\.|\\s|\\-*)(.*)", "{{ if .Config.enhancedAnime4 }}$1 E$3 $5{{ else }}$1$2$3$4$5{{ end }}"]
     - name: re_replace # episode number at the end "123" to "E123"
-      args: ["(.*)(\\.|\\s|\\-)(\\d{2,4})(\\.|\\s|\\-*)(.*)", "{{ if .Config.enhancedAnime }}$1 E$3 $5{{ else }}$1$2$3$4$5{{ end }}"]
+      args: ["(.*)(\\.|\\s|\\-)(\\d{2,3})(\\.|\\s|\\-*)(.*)", "{{ if .Config.enhancedAnime }}$1 E$3 $5{{ else }}$1$2$3$4$5{{ end }}"]
     # END ANIME HACK
     - name: replace
       args: ["\"", ""]


### PR DESCRIPTION
#### Indexer/Tracker
yggtorrent/cookie

#### Description
reverts https://github.com/Prowlarr/Indexers/commit/9c3206699eeb4d98ae311ad8086f90b60086b2e4 in place of https://github.com/Jackett/Jackett/commit/aae44fd2d521d63be1e7a91779a7733f016d3311

#### Issues Fixed or Closed by this PR

* Fixes #XXXX