### PR TITLE
Remove automatic redirect follow option in nCore

### DIFF
--- a/definitions/v7/ncore.yml
+++ b/definitions/v7/ncore.yml
@@ -85,7 +85,6 @@ login:
 search:
   paths:
     - path: torrents.php
-      followredirect: true
   inputs:
     nyit_filmek_resz: "true"
     nyit_sorozat_resz: "true"


### PR DESCRIPTION
#### Indexer/Tracker
nCore

#### Description
This commit will fix the nCore indexer by removing the automatic redirect follow which did not allow the login properly to the indexer page.
