### PR TITLE
World of Tomorrow url changed

### DIFF
--- a/definitions/v7/world-of-tomorrow.yml
+++ b/definitions/v7/world-of-tomorrow.yml
@@ -6,7 +6,7 @@ language: de-DE
 type: private
 encoding: UTF-8
 links:
-  - https://wotreworked.xyz/
+  - https://w-o-t.pro
 legacylinks:
   - https://world-of-tomorrow.eu/
 


### PR DESCRIPTION
The URL of World of Tomomorrow has been changed from http://wotreworked.xyz to https://w-o-t.pro/.

#### Indexer/Tracker
[World of Tomorrow](https://w-o-t.pro)

#### Description
Changed the URL

#### Issues Fixed or Closed by this PR

* Fixes #322