### PR TITLE
Exclude possible UNIT3D inputs since they depend on v9's allowEmptyInputs

### DIFF
--- a/definitions/v7/schema.json
+++ b/definitions/v7/schema.json
@@ -460,7 +460,7 @@
                     "type": "object",
                     "additionalProperties": false,
                     "patternProperties": {
-                        "^((\\$raw)|[A-Za-z0-9.\\-_[\\]]*)$": {
+                        "^((\\$raw)|(?!^(seasonNumber|episodeNumber)$)[A-Za-z0-9.\\-_[\\]]*)$": {
                             "oneOf": [
                                 {"type": "number"},
                                 {"type": "string"},

--- a/definitions/v8/schema.json
+++ b/definitions/v8/schema.json
@@ -460,7 +460,7 @@
                     "type": "object",
                     "additionalProperties": false,
                     "patternProperties": {
-                        "^((\\$raw)|[A-Za-z0-9.\\-_[\\]]*)$": {
+                        "^((\\$raw)|(?!^(seasonNumber|episodeNumber)$)[A-Za-z0-9.\\-_[\\]]*)$": {
                             "oneOf": [
                                 {"type": "number"},
                                 {"type": "string"},


### PR DESCRIPTION
Force UNIT3D definitions changed for `AllowEmptyInputs` to v9.