### PR TITLE
GimmePeers Blah Query Value Update

### DIFF
--- a/definitions/v7/gimmepeers.yml
+++ b/definitions/v7/gimmepeers.yml
@@ -97,7 +97,7 @@ search:
     $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
     search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}{{ if .Query.Genre }} genre:{{ .Query.Genre }}{{ else }}{{ end }}"
     # 0 title, 1 nfo, 2 filelist, 3 title+nfo, 4 IMDB (tt#)
-    blah: "{{ if or .Query.IMDBID .Query.Genre }}4{{ else }}0{{ end }}"
+    blah: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}{{ if .Query.Genre }}3{{ else }}0{{ end }}"
     # 0 active only, 1 dead only
     incldead: 0
     sort: "{{ .Config.sort }}"

--- a/definitions/v7/gimmepeers.yml
+++ b/definitions/v7/gimmepeers.yml
@@ -96,8 +96,8 @@ search:
   inputs:
     $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
     search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}{{ if .Query.Genre }} genre:{{ .Query.Genre }}{{ else }}{{ end }}"
-    # 0 title, 1 nfo, 2 filelist, 3 title+nfo
-    blah: "{{ if or .Query.IMDBID .Query.Genre }}3{{ else }}0{{ end }}"
+    # 0 title, 1 nfo, 2 filelist, 3 title+nfo, 4 IMDB (tt#)
+    blah: "{{ if or .Query.IMDBID .Query.Genre }}4{{ else }}0{{ end }}"
     # 0 active only, 1 dead only
     incldead: 0
     sort: "{{ .Config.sort }}"

--- a/definitions/v7/gimmepeers.yml
+++ b/definitions/v7/gimmepeers.yml
@@ -96,8 +96,8 @@ search:
   inputs:
     $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
     search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}{{ if .Query.Genre }} genre:{{ .Query.Genre }}{{ else }}{{ end }}"
-    # 0 title, 1 nfo, 2 filelist, 3 title+nfo, 4 IMDB (tt#)
-    blah: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}{{ if .Query.Genre }}3{{ else }}0{{ end }}"
+    # 0 title, 1 nfo, 2 filelist, 3 title+nfo, 4 imdb
+    blah: "{{ if .Query.IMDBID }}4{{ else }}{{ end }}{{ if .Query.Genre }}3{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.Genre }}{{ else }}0{{ end }}"
     # 0 active only, 1 dead only
     incldead: 0
     sort: "{{ .Config.sort }}"


### PR DESCRIPTION
#### Indexer/Tracker
 https://github.com/Prowlarr/Indexers/blob/master/definitions/v7/gimmepeers.yml

#### Description
GP recently released an updated IMDb ID search option for queries. This change was added because queries against "blah=3" were turning up inconsistent results because not all "title" or "NFO" contained the IMDb. The default "blah" value in the gimmepeers.yaml file is 3, but it should now be changed to 4.

#### Issues Fixed or Closed by this PR
Revised "blah" value for better matches.

* Fixes #XXXX