### PR TITLE
Update xxxclub.yml

### DIFF
--- a/definitions/v7/xxxclub.yml
+++ b/definitions/v7/xxxclub.yml
@@ -33,7 +33,7 @@ settings:
 
 download:
   selectors:
-    - selector: a[href^="/torrents/download/"]
+    - selector: a[href^="magnet:?xt="]
       attribute: href
 
 search:


### PR DESCRIPTION
Change XXXClub to support maglinks instead of torrents

#### Indexer/Tracker
XXXClub

#### Description
Changes XXXclub from Downloading via Torrent File and Changes to Support maglink

#### Issues Fixed or Closed by this PR
Potential Resolves #343