### PR TITLE
Add addukrainiantotitle option for UTOPIA tracker

### DIFF
--- a/definitions/v7/utopia.yml
+++ b/definitions/v7/utopia.yml
@@ -30,6 +30,10 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: addukrainiantotitle
+    type: checkbox
+    label: Add UKR to end of all titles to improve language detection by Sonarr and Radarr. Will cause English-only results to be misidentified.
+    default: false
   - name: sort
     type: select
     label: Sort requested from site
@@ -91,6 +95,8 @@ search:
       filters:
         - name: re_replace
           args: ["\\.", " "]
+        - name: append
+          args: "{{ if .Config.addukrainiantotitle }} UKR{{ else }}{{ end }}"
     details:
       selector: details_link
     download:


### PR DESCRIPTION
#### Indexer/Tracker

#### Description

UTOPIA is a Ukrainian tracker with movies and tv series with Ukrainian dubbing. Releases from UTOPIA misidentified as English, despite being a Ukrainian tracker.

This PR introduces `addukrainiantotitle` option, similarly to how various Russian trackers work. This is going to help properly identifying releases.

#### Issues Fixed or Closed by this PR

-
