### PR TITLE
hdforever: fix search with release year

### DIFF
--- a/definitions/v7/hdforever.yml
+++ b/definitions/v7/hdforever.yml
@@ -95,11 +95,11 @@ login:
     selector: a[href^="logout.php?auth="]
 
 search:
-  # https://hdf.world/torrents.php?groupname=blood&freetorrent=1&order_by=time&order_way=desc&action=advanced&searchsubmit=1
+  # https://hdf.world/torrents.php?searchstr=Un+Singe+en+hiver+1962&freetorrent=1&order_by=time&order_way=desc&action=advanced&searchsubmit=1
   path: torrents.php
   inputs:
     $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
-    groupname: "{{ .Keywords }}"
+    searchstr: "{{ .Keywords }}"
     order_by: "{{ .Config.sort }}"
     order_way: "{{ .Config.type }}"
     action: advanced


### PR DESCRIPTION
#### Indexer/Tracker
HF-Forever

#### Description
On radarr, you had to select `Remove year from search string` to make it works. Now, by replacing `groupname` by `searchstr`, the research with release year works.
`searchstr` is the one used on the website.
`&freetorrent=1` works too.

#### Issues Fixed or Closed by this PR

* None