### PR TITLE
torrent9: remove no longer necessary UA header

### DIFF
--- a/definitions/v7/torrent9.yml
+++ b/definitions/v7/torrent9.yml
@@ -118,10 +118,6 @@ search:
     - name: replace
       args: [" ", "-"]
 
-  headers:
-    # site blocks Prowlarr's Linux User-Agent, so use Prowlarr's Windows User-Agent instead
-    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"]
-
   rows:
     selector: table.table-striped > tbody > tr
     filters:

--- a/definitions/v9/torrent9.yml
+++ b/definitions/v9/torrent9.yml
@@ -118,10 +118,6 @@ search:
     - name: replace
       args: [" ", "-"]
 
-  headers:
-    # site blocks Prowlarr's Linux User-Agent, so use Prowlarr's Windows User-Agent instead
-    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"]
-
   rows:
     selector: table.table-striped > tbody > tr
     filters:


### PR DESCRIPTION
#### Indexer/Tracker
torrent9

#### Description
not sure if this would have been covered by the definitions merge for https://github.com/Jackett/Jackett/commit/2c267350044906742574a06085705356edd81981, but as the comment had been changed I've opened this PR

close if unnecessary

#### Issues Fixed or Closed by this PR

* Fixes #XXXX