### PR TITLE
Added support for imdbid, changed descriptions to include all tags

### DIFF
--- a/definitions/v7/cathoderaytube.yml
+++ b/definitions/v7/cathoderaytube.yml
@@ -18,8 +18,8 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, genre]
-    movie-search: [q, genre]
+    tv-search: [q, season, ep, genre, imdbid]
+    movie-search: [q, genre, imdbid]
 
 settings:
   - name: info_2fa
@@ -76,7 +76,7 @@ search:
     - path: torrents.php
   inputs:
     $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
-    searchtext: "{{ .Keywords }}"
+    searchtext: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
     order_by: "{{ .Config.sort }}"
     order_way: "{{ .Config.type }}"
     action: advanced
@@ -128,7 +128,7 @@ search:
         - name: validate
           args: "Action, Adventure, Animation, Comedy, Crime, Documentary, Drama, Family, Fantasy, History, Horror, Kids, Music, Mystery, News, Reality, Romance, SciFi, Soap, Talk, Thriller, War, Western"
     description:
-      text: "{{ .Result.genre }}"
+      selector: div.tags
     poster:
       selector: td:nth-child(2) > script
       filters:


### PR DESCRIPTION
instead of copying Genre

#### Indexer/Tracker
Cathode-Ray.Tube

#### Description
Add imdbid support for tv and movies
Changes description to include all tags instead of only the genres. This is especially useful for CRT since the title in CRT doesn't include any information about the format or resolution, this is only communicated through the tags.

#### Issues Fixed or Closed by this PR
