### PR TITLE
updated torrentproject url replacement

### DIFF
--- a/definitions/v7/torrentproject2.yml
+++ b/definitions/v7/torrentproject2.yml
@@ -56,6 +56,8 @@ download:
           args: ["https://mylink.me.uk/?url=", ""]
         - name: replace
           args: ["https://mylink.cx/?url=", ""]
+        - name: replace
+          args: ["https://mylink.cloud/?url=", ""]
         - name: urldecode
 
 search:


### PR DESCRIPTION
#### Indexer/Tracker
torrentproject2

#### Description
I updated the replacement string to correctly capture the magnet url and avoid infinite redirect

#### Issues Fixed or Closed by this PR
None