### PR TITLE
shanaproject: add timezone info to date parsing

### DIFF
--- a/definitions/v7/shanaproject.yml
+++ b/definitions/v7/shanaproject.yml
@@ -87,8 +87,10 @@ search:
           args: ["April", "Apr"]
         - name: re_replace
           args: ["March", "Mar"]
+        - name: append
+          args: " +00:00" # GMT
         - name: dateparse
-          args: "MMM d, yyyy, h:mm tt"
+          args: "MMM d, yyyy, h:mm tt zzz"
     date_abbr:
       # May 8, 2022, 6 a.m.
       selector: div.release_20:contains(".m."):not(:contains(":"))


### PR DESCRIPTION
#### Indexer/Tracker
shanaproject

#### Description
These changes ensures accurate date parsing considering the GMT +00:00 timezone used by the shanaproject tracker.