### PR TITLE
Update anilibria.yml

### DIFF
--- a/definitions/v9/anilibria.yml
+++ b/definitions/v9/anilibria.yml
@@ -167,6 +167,7 @@ search:
           args: ["(?i)^(?!S\\d+).*", ""]
     _season_number_alternative:
       selector: ..names.alternative
+      optional: true
       filters:
         - name: re_replace
           args: ["(?i)\\bPart\\s*\\d+\\s*$", ""]


### PR DESCRIPTION
_season_number_alternative could be null

#### Indexer/Tracker
Anilibria

#### Description
In the latest request to Anilibria the error has been thrown.
`[v1.15.0.4350] NzbDrone.Core.Indexers.Definitions.Cardigann.Exceptions.CardigannException: Error while parsing field=_season_number_alternative, selector=..names.alternative, value=<null>: Value cannot be null. (Parameter 'input')`
Checking its JSON response found that some titles could not have alternative names.

Here is an example:
`{"list":[{"names":{"ru":"Монолог фармацевта","en":"Kusuriya no Hitorigoto","alternative":null}...`

#### Issues Fixed or Closed by this PR