### PR TITLE
fix: Bittorrentfiles datetime parsing error

### DIFF
--- a/definitions/v9/Bittorrentfiles.yml
+++ b/definitions/v9/Bittorrentfiles.yml
@@ -208,7 +208,7 @@ search:
         - name: replace
           args: ["Gestern", "Yesterday"]
         - name: append
-          args: " +01:00" # CET
+          args: "+01:00" # CET
     date_year:
       # 30.02.2018 23:12:50
       selector: td:nth-child(10):contains("."):contains(":")
@@ -217,7 +217,7 @@ search:
         - name: split
           args: ["b", 0]
         - name: append
-          args: " +01:00" # CET
+          args: "+01:00" # CET
         - name: dateparse
           args: "dd.MM.yyyy HH:mm:ss zzz"
     date:


### PR DESCRIPTION
#### Indexer/Tracker
Bittorrentfiles

#### Description
Fixes datetime parsing error resulting in negative ages:

```
Debug|Cardigann|Bittorrentfiles: Error while parsing DateTime "15.04.2024 14:34:33  +01:00", using layout "dd.MM.yyyy HH:mm:ss zzz" (dd.MM.yyyy HH:mm:ss zzz): String '15.04.2024 14:34:33  +01:00' was not recognized as a valid DateTime.
```