### PR TITLE
Update YGGTorrent as Private tracker, and add new URL

### DIFF
--- a/definitions/v9/yggcookie.yml
+++ b/definitions/v9/yggcookie.yml
@@ -1,14 +1,14 @@
 ---
 id: yggcookie
 name: YGGcookie
-description: "YGGTorrent is a FRENCH Semi-Private Torrent Tracker for 0DAY / GENERAL"
+description: "YGGTorrent is a FRENCH Private Torrent Tracker for 0DAY / GENERAL"
 language: fr-FR
-type: semi-private
+type: private
 encoding: UTF-8
 followredirect: true
 requestDelay: 2
 links:
-  - https://www3.yggtorrent.cool/
+  - https://www.ygg.re/
 legacylinks:
   - https://ww3.yggtorrent.si/
   - https://yggtorrent.si/
@@ -26,6 +26,7 @@ legacylinks:
   - https://www3.yggtorrent.do/
   - https://www3.yggtorrent.wtf/
   - https://www3.yggtorrent.qa/
+  - https://www3.yggtorrent.cool/
 
 caps:
   categorymappings:

--- a/definitions/v9/yggtorrent.yml
+++ b/definitions/v9/yggtorrent.yml
@@ -1,14 +1,14 @@
 ---
 id: yggtorrent
 name: YGGtorrent
-description: "YGGTorrent is a FRENCH Semi-Private Torrent Tracker for 0DAY / GENERAL"
+description: "YGGTorrent is a FRENCH Private Torrent Tracker for 0DAY / GENERAL"
 language: fr-FR
-type: semi-private
+type: private
 encoding: UTF-8
 followredirect: true
 requestDelay: 2
 links:
-  - https://www3.yggtorrent.cool/
+  - https://www.ygg.re/
 legacylinks:
   - https://ww3.yggtorrent.si/
   - https://yggtorrent.si/
@@ -26,6 +26,7 @@ legacylinks:
   - https://www3.yggtorrent.do/
   - https://www3.yggtorrent.wtf/
   - https://www3.yggtorrent.qa/
+  - https://www3.yggtorrent.cool/
 
 caps:
   categorymappings:


### PR DESCRIPTION
#### Indexer/Tracker

- YGGTorrent
- YGGCookie

#### Description
As mentioned in #448 , YGGTorrent has changed its URL to https://www.ygg.re/. Moreover, the tracker is now private.

#### Issues Fixed or Closed by this PR

* Fixes #448 