### PR TITLE
[bwtorrents.yml] Added `andmatch` filter

### DIFF
--- a/definitions/v10/bwtorrents.yml
+++ b/definitions/v10/bwtorrents.yml
@@ -180,6 +180,8 @@ search:
 
   rows:
     selector: table[width="1200"] > tbody > tr:has(a[href^="download.php/"])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/definitions/v9/bwtorrents.yml
+++ b/definitions/v9/bwtorrents.yml
@@ -182,6 +182,8 @@ search:
 
   rows:
     selector: table[width="1200"] > tbody > tr:has(a[href^="download.php/"])
+    filters:
+      - name: andmatch
 
   fields:
     category:


### PR DESCRIPTION
#### Indexer/Tracker
bwtorrents.yml

#### Description
Added `andmatch` filter to improve search accuracy by ensuring only relevant search results are returned.

#### Current

![image](https://github.com/user-attachments/assets/bcd5a0b3-1df1-4b36-91fe-d5f1fbacad70)

#### Changes

![image](https://github.com/user-attachments/assets/59803b13-5ec7-40e2-8b4d-f0b29353d819)
