### PR TITLE
F1Carreras : Update keyword filter for improved search accuracy

### DIFF
--- a/definitions/v10/f1carreras-api.yml
+++ b/definitions/v10/f1carreras-api.yml
@@ -99,8 +99,8 @@ search:
       args: ["\\.", " "]  # Replace dots with spaces
     - name: re_replace  # Convert S2024E97 → S2024x97
       args: ["\\bS(\\d{2,4})E(\\d{2,4})\\b", "S$1x$2"]
-    - name: re_replace  # Convert S2024 to 2024 (ONLY if NOT followed by 'x')
-      args: ["\\bS(\\d{2,4})(?!x\\d{2,4})\\b", "$1"]
+    - name: re_replace  # Convert S2024 to 2024
+      args: ["\\bS(\\d{2,4})\\b", "$1"]
     - name: trim
 
   rows:

--- a/definitions/v10/f1carreras-api.yml
+++ b/definitions/v10/f1carreras-api.yml
@@ -97,8 +97,10 @@ search:
   keywordsfilters:
     - name: re_replace
       args: ["\\.", " "]
-    - name: re_replace # S2024 to 2024 and S2024E97 to 2024 97
-      args: ["\\b(?:S(\\d{2,4}))(?:E(\\d{2,4}))?\\b", "$1 $2"]
+    # disabled to find better matches as agreed on F1Carreras Discord
+    # searching for "Formula1 2024 97" returns nothing, but "Formula1 S2024E97" works just fine
+    # - name: re_replace # S2024 to 2024 and S2024E97 to 2024 97
+    #   args: ["\\b(?:S(\\d{2,4}))(?:E(\\d{2,4}))?\\b", "$1 $2"]
     - name: trim
 
   rows:

--- a/definitions/v10/f1carreras-api.yml
+++ b/definitions/v10/f1carreras-api.yml
@@ -96,11 +96,11 @@ search:
 
   keywordsfilters:
     - name: re_replace
-      args: ["\\.", " "]
-    # disabled to find better matches as agreed on F1Carreras Discord
-    # searching for "Formula1 2024 97" returns nothing, but "Formula1 S2024E97" works just fine
-    # - name: re_replace # S2024 to 2024 and S2024E97 to 2024 97
-    #   args: ["\\b(?:S(\\d{2,4}))(?:E(\\d{2,4}))?\\b", "$1 $2"]
+      args: ["\\.", " "]  # Replace dots with spaces
+    - name: re_replace  # Convert S2024E97 → S2024x97
+      args: ["\\bS(\\d{2,4})E(\\d{2,4})\\b", "S$1x$2"]
+    - name: re_replace  # Convert S2024 to 2024 (ONLY if NOT followed by 'x')
+      args: ["\\bS(\\d{2,4})(?!x\\d{2,4})\\b", "$1"]
     - name: trim
 
   rows:


### PR DESCRIPTION
Disabled regex to find better matches as agreed on F1Carreras Discord. Searching for "Formula1 2024 97" returns nothing, but "Formula1 S2024E97" works just fine.