### PR TITLE
correct row index newheaven.yml

### DIFF
--- a/definitions/v11/newheaven.yml
+++ b/definitions/v11/newheaven.yml
@@ -194,13 +194,13 @@ search:
     date:
       text: "{{ if or .Result.date_year .Result.date_day }}{{ or .Result.date_year .Result.date_day }}{{ else }}now{{ end }}"
     size:
-      selector: td:nth-child(4)
+      selector: td:nth-child(3)
     grabs:
-      selector: td:nth-child(6)
+      selector: td:nth-child(5)
     seeders:
-      selector: td:nth-child(7)
+      selector: td:nth-child(6)
     leechers:
-      selector: td:nth-child(8)
+      selector: td:nth-child(7)
     downloadvolumefactor:
       case:
         div:contains("50% DL"): 0.5


### PR DESCRIPTION
currently row indexes are messed up, correct them to -1

#### Indexer/Tracker
Newheaven.yml

#### Description
The Row index seems to be changed. Seeds/leech and size is currently incorrectly displayed.
![image](https://github.com/user-attachments/assets/66f9b248-0607-46c1-9dfb-c715e583a154)
It has to be set to -1 then everything will be fine.

#### Issues Fixed or Closed by this PR
