### PR TITLE
Add sewerpt indexer

### DIFF
--- a/definitions/v10/sewerpt.yml
+++ b/definitions/v10/sewerpt.yml
@@ -1,0 +1,153 @@
+id: sewerpt
+name: SewerPT
+description: "SewerPT (下水道) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
+language: zh-CN
+type: private
+encoding: UTF-8
+links:
+  - https://sewerpt.com/
+
+caps:
+  categorymappings:
+  - {id: 401, cat: Movies, desc: "电影 / Movies"}
+  - {id: 402, cat: TV, desc: "电视剧 / TV Series"}
+  - {id: 403, cat: TV/Documentary, desc: "综艺 / TV Shows"}
+  - {id: 404, cat: TV/Documentary, desc: "纪录片 / Documentaries"}
+  - {id: 405, cat: TV/Anime, desc: "动漫 / Animations"}
+  - {id: 408, cat: Audio, desc: "音乐 / Music"}
+  - {id: 409, cat: Other, desc: "其他 / Misc"}
+  
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid, doubanid]
+    movie-search: [q, imdbid, doubanid]
+    music-search: [q]
+
+settings:
+  - name: cookie
+    type: text
+    label: Cookie
+  - name: info_cookie
+    type: info_cookie
+  - name: freeleech
+    type: checkbox
+    label: Search freeleech only
+    default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 4
+    options:
+      4: created
+      7: seeders
+      5: size
+      1: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
+  - name: info_activity
+    type: info
+    label: Account Inactivity
+    default: "Account retention rules:<ol><li>Dou Sheng users and above will be retained forever</li><li>Dou Huang and above will not have their account deleted after parking (in the control panel)</li><li>Users with a parked account will be deleted if they do not log in for 180 consecutive days</li><li>Users with a non-parked account will be banned if they do not log in for 45 consecutive days</li><li>Users with no traffic (ie, upload/download data are both 0) will be banned if they do not log in for 7 consecutive days.</li></ol>"
+
+login:
+  method: cookie
+  inputs:
+    cookie: "{{ .Config.cookie }}"
+  test:
+    path: index.php
+    selector: a[href="logout.php"]
+
+search:
+  paths:
+    - path: torrents.php
+  inputs:
+    $raw: "{{ range .Categories }}cat{{.}}=1&{{end}}"
+    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }} {{ else }}{{ .Keywords }}{{ end }}{{ if .Query.DoubanID }}{{ .Query.DoubanID }}{{ else }}{{ end }}"
+    # 0 incldead, 1 active, 2 dead
+    incldead: 0
+    # 0 all, 1 normal, 2 free, 3 2x, 4 2xfree, 5 50%, 6 2x50%, 7 30%
+    spstate: "{{ if .Config.freeleech }}2{{ else }}0{{ end }}"
+    # 0 title, 1 descr, 3 uploader, 4 imdburl (not working)
+    search_area: "{{ if or .Query.IMDBID .Query.DoubanID }}1{{ else }}0{{ end }}"
+    # 0 AND, 1 OR, 2 exact
+    search_mode: 0
+    sort: "{{ .Config.sort }}"
+    type: "{{ .Config.type }}"
+    notnewword: 1
+
+  rows:
+    selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])
+
+  fields:
+    category:
+      selector: a[href*="cat="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
+    title:
+      selector: a[title][href^="details.php?id="]
+      attribute: title
+    details:
+      selector: a[href^="details.php?id="]
+      attribute: href
+    download:
+      selector: a[href^="download.php?id="]
+      attribute: href
+    size:
+      selector: td.rowfollow:nth-child(5)
+    seeders:
+      selector: td.rowfollow:nth-child(6)
+    leechers:
+      selector: td.rowfollow:nth-child(7)
+    grabs:
+      selector: td.rowfollow:nth-child(8)
+    date_elapsed:
+      selector: td.rowfollow:nth-child(4) > span[title]
+      attribute: title
+      filters:
+        - name: append
+          args: " +08:00"
+        - name: dateparse
+          args: "yyyy-MM-dd HH:mm:ss zzz"
+    date_added:
+      selector: td.rowfollow:nth-child(4):not(:has(span))
+      filters:
+        - name: append
+          args: " +08:00"
+        - name: dateparse
+          args: "yyyy-MM-ddHH:mm:ss zzz"
+    date:
+      text: "{{ or .Result.date_elapsed .Result.date_added }}"
+    downloadvolumefactor:
+      case:
+        img.pro_free: 0
+        img.pro_free2up: 0
+        img.pro_50pctdown: 0.5
+        img.pro_50pctdown2up: 0.5
+        "*": 1
+    uploadvolumefactor:
+      case:
+        img.pro_free2up: 2
+        img.pro_50pctdown2up: 2
+        "*": 1
+    minimumratio:
+      case:
+        img[title="H&R"]: 1.0
+        "*": 0.4
+    minimumseedtime:
+      case:
+        img[title="H&R"]: 259200
+        "*": 86400
+    description:
+      selector: td.rowfollow:nth-child(2)
+      remove: a, font, img, span


### PR DESCRIPTION
This PR adds support for the Chinese private tracker [sewerpt.com](https://sewerpt.com).

- Platform: NexusPHP-based
- Type: Private tracker (requires invite)
- Login: Cookie-based authentication
- Features:
  - Full category mapping
  - Freeleech / 2x / 50% support
  - Upload/download factor handling
  - Minimum ratio and seeding time support (H&R-aware)
  - Note: IMDb / Douban ID not directly supported by sewerpt; keyword search only

Indexer was tested and is functioning correctly in a live environment via Prowlarr (v1.33.3+).