### PR TITLE
Add cookie-based authentication to YTS indexer

### DIFF
--- a/definitions/v10/yts.yml
+++ b/definitions/v10/yts.yml
@@ -37,7 +37,20 @@ caps:
     search: [q]
     movie-search: [q, imdbid]
 
-settings: []
+settings:
+  - name: cookie
+    type: text
+    label: Cookie
+  - name: info_cookie
+    type: info_cookie
+
+login:
+  method: cookie
+  inputs:
+    cookie: "{{ .Config.cookie }}"
+  test:
+    path: /
+    selector: a[href*="logout"]
 
 search:
   paths:


### PR DESCRIPTION
#### Indexer/Tracker


#### Description
- I tried authenticating with POST and form method, but failed.
- This pr fixes the issue with the cookie method.
- Feel free to reject this pr if someone successfully makes it work with the other options.

#### Issues Fixed or Closed by this PR
* Fixes #550 