### PR TITLE
Fixed: sync script CI not detecting jackett remote

### DIFF
--- a/.github/workflows/indexer-sync.yml
+++ b/.github/workflows/indexer-sync.yml
@@ -78,6 +78,10 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global fetch.prune true
+          # Add Jackett remote if it doesn't exist
+          if ! git remote get-url z_Jackett >/dev/null 2>&1; then
+            git remote add z_Jackett https://github.com/Jackett/Jackett.git
+          fi
           git config --global remote.z_Jackett.tagOpt --no-tags
 
       - name: Run indexer sync


### PR DESCRIPTION
Added explicit check and setup for z_Jackett remote in CI workflow to ensure the remote exists before the sync script tries to use it.

#### Indexer/Tracker


#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Issues Fixed or Closed by this PR

* Fixes #XXXX