### PR TITLE
fix: match correct seeders and leechers

### DIFF
--- a/definitions/v11/newheaven.yml
+++ b/definitions/v11/newheaven.yml
@@ -200,9 +200,9 @@ search:
     grabs:
       selector: td:nth-child(7)
     seeders:
-      selector: td:nth-child(8)
+      selector: a[href*="#seeders"]
     leechers:
-      selector: td:nth-child(9)
+      selector: a[href*="#leechers"]
     downloadvolumefactor:
       case:
         div:contains("50% DL"): 0.5


### PR DESCRIPTION
#### Indexer/Tracker

NewHeaven

#### Description
Currently the Seeders/Leechers show up as `0/100` due to incorrect matching.
This PR makes use of the Links ending in `#seeders` and `#leechers`.

#### Issues Fixed or Closed by this PR

There's not open issue for that afaik.