### PR TITLE
fix: (newheaven) ensure default 0/0 for seeders/leechers

### DIFF
--- a/definitions/v11/newheaven.yml
+++ b/definitions/v11/newheaven.yml
@@ -200,9 +200,13 @@ search:
     grabs:
       selector: td:nth-child(7)
     seeders:
-      selector: a[href*="#seeders"]
+      selector: a[href$="#seeders"]
+      optional: true
+      default: 0
     leechers:
-      selector: a[href*="#leechers"]
+      selector: a[href$="#leechers"]
+      optional: true
+      default: 0
     downloadvolumefactor:
       case:
         div:contains("50% DL"): 0.5


### PR DESCRIPTION
#### Indexer/Tracker

NewHeaven

#### Description
Seems like in case there are no seeders/leechers, there's no such url with `#seeders` or `#leechers`, so we
use default `0`

#### Issues Fixed or Closed by this PR