### PR TITLE
fix: (newheaven) use correct nth-child and remove files

### DIFF
--- a/definitions/v11/newheaven.yml
+++ b/definitions/v11/newheaven.yml
@@ -193,12 +193,10 @@ search:
           args: "dd.MM.yyyy HH:mm zzz"
     date:
       text: "{{ if or .Result.date_year .Result.date_day }}{{ or .Result.date_year .Result.date_day }}{{ else }}now{{ end }}"
-    files:
-      selector: td:nth-child(5)
     size:
       selector: td:nth-child(4)
     grabs:
-      selector: td:nth-child(7)
+      selector: td:nth-child(6)
     seeders:
       selector: a[href$="#seeders"]
       optional: true


### PR DESCRIPTION
#### Indexer/Tracker

NewHeaven

#### Description
- Wrong `nth-child` being used for grabs
- There are no information for `files` on the search result page
