### PR TITLE
feat: add more pages to fappaizuri searches

### DIFF
--- a/definitions/v11/fappaizuri.yml
+++ b/definitions/v11/fappaizuri.yml
@@ -83,8 +83,20 @@ download:
 
 search:
   paths:
-    # https://fappaizuri.me/torrents-search.php?search=&c8=1&c6=1&incldead=1&freeleech=0&lang=0
+    # page returns only 25 entries
+    # https://fappaizuri.me/torrents-search.php?search=&c8=1&c6=1&incldead=1&freeleech=0&lang=0&page=0
     - path: torrents-search.php
+      inputs:
+        page: 0
+    - path: torrents-search.php
+      inputs:
+        page: 1
+    - path: torrents-search.php
+      inputs:
+        page: 2
+    - path: torrents-search.php
+      inputs:
+        page: 3
 
   inputs:
     $raw: "{{ range .Categories }}&c{{.}}=1&{{end}}"


### PR DESCRIPTION
#### Indexer/Tracker

fappaizuri.me

#### Description
Updated search paths in fappaizuri.yml to include pagination. So rather than only fetching 25 entries, we now fetch 100 entries.

Found similar pattern in https://github.com/Prowlarr/Indexers/blob/b68f031f637aae8d456b9f1d1ba09eb6688b598c/definitions/v11/amigosshare.yml#L128-L155

#### Issues Fixed or Closed by this PR
None