### PR TITLE
torrent-heaven: restore indexer

### DIFF
--- a/scripts/blocklist.txt
+++ b/scripts/blocklist.txt
@@ -11,6 +11,5 @@ yggcookie.yml
 sharewood.yml
 anirena.yml
 torrentgalaxy.yml
-torrent-heaven.yml
 scenelinks.yml
 therarbg.yml


### PR DESCRIPTION
#### Indexer/Tracker
Torrent Heaven

#### Description
Previously removed due to blocking of Prowlarr UA. TH staff member has now posted in Servarr Discord (indexer-requests channel) that they want the indexer restored and will no longer block the UA.

#### Issues Fixed or Closed by this PR

* Fixes #XXXX