### PR TITLE
Add yggtorrent-turbo to blocklist

### DIFF
--- a/scripts/blocklist.txt
+++ b/scripts/blocklist.txt
@@ -7,6 +7,7 @@ uniongangcookie.yml
 ygg-api.yml
 yggtorrent.yml
 yggcookie.yml
+yggtorrent-turbo.yml
 
 sharewood.yml
 anirena.yml


### PR DESCRIPTION
#### Indexer/Tracker
YggTorrent

#### Description
Should be added before next definitions merge.

https://github.com/Jackett/Jackett/commit/0965317bb3189c582a83c58854a92c7a89974420

#### Issues Fixed or Closed by this PR

* Fixes #XXXX