### PR TITLE
schema (v11): add allowtvsearchimdb to Caps

### DIFF
--- a/definitions/v11/schema.json
+++ b/definitions/v11/schema.json
@@ -123,8 +123,7 @@
                 "allowrawsearch": {
                     "type": "boolean"
                 },
-
-                "allowtvsearchimdb":{
+                "allowtvsearchimdb": {
                     "type":"boolean"
                 }
             },


### PR DESCRIPTION
#### Indexer/Tracker

* N/A

#### Description
Adds `allowtvsearchimdb` to Cardigann caps, to align with upstream. 

Isn't used by Prowlarr and is backwards-compatible, therefore keeping it as a minor change

#### Issues Fixed or Closed by this PR

* None