### PR TITLE
Fix ArabP2P selectors and date format

### DIFF
--- a/definitions/v11/arabp2p.yml
+++ b/definitions/v11/arabp2p.yml
@@ -140,7 +140,7 @@ search:
     - name: trim
 
   rows:
-    selector: table#torrents_list_p > tbody > tr:has(a[href^="download.php?id="]), table#torrents_list_p > tbody > tr:has(a[href^="magnet:?xt="])
+    selector: table#torrents_list_p > tr:has(a[href^="download.php?id="]), table#torrents_list_p > tr:has(a[href^="magnet:?xt="])
     filters:
       - name: andmatch
 
@@ -192,13 +192,13 @@ search:
       # auto adjusted by site account profile
       filters:
         - name: dateparse
-          args: "MM-yy-dd HH:mm:ss tt"
+          args: "yy-MM-dd hh:mm:ss tt"
     size:
       selector: span.size
     seeders:
-      selector: span[title="Seeders"]
+      selector: span[title="Seeders"] a
     leechers:
-      selector: span[title="Leechers"]
+      selector: span[title="Leechers"] a
     downloadvolumefactor:
       case:
         span.free: 0


### PR DESCRIPTION
## Summary
- Remove `tbody` from row selector (site HTML structure changed)
- Fix seeders/leechers selectors to target the anchor element containing the count
- Fix date format from `MM-yy-dd` to `yy-MM-dd` to match actual site format

## Changes
The site's HTML structure has been updated:
- Torrent rows no longer have an explicit `tbody` wrapper
- Seeder/leecher counts are now inside `<a>` tags within the stat spans
- Date format in the `title` attribute is `yy-MM-dd hh:mm:ss tt`

## Testing
Verified against live site with authenticated session.