### PR TITLE
Fixed: Update -r to accept argument

### DIFF
--- a/scripts/indexer-sync-v2.sh
+++ b/scripts/indexer-sync-v2.sh
@@ -279,7 +279,7 @@ initialize_script() {
     log "INFO" "Using Python validation"
 }
 
-while getopts "frpzab:m:c:u:j:R:J:n:o:dv" opt; do
+while getopts "fpzar:b:m:c:u:j:R:J:n:o:dv" opt; do
     case ${opt} in
     f)
         # No Arg


### PR DESCRIPTION
#### Description
-r was meant to accept an argument but was not set correctly in the optstring

See:
```
r)
        prowlarr_remote_name=$OPTARG
        ;;
```
```
"  -r REMOTE   Prowlarr remote name (default: origin)"
```
