### PR TITLE
fix(lacale): fix download link by replacing localhost with production…

### DIFF
--- a/definitions/v11/lacale-api.yml
+++ b/definitions/v11/lacale-api.yml
@@ -138,6 +138,8 @@ search:
     download:
       selector: link
       filters:
+        - name: replace
+          args: ["http://localhost:3000", "https://la-cale.space"]
         - name: append
           args: "?passkey={{ .Config.passkey }}"
     size:


### PR DESCRIPTION
… domain

#### Indexer/Tracker
lacale-api (La Cale)

#### Description
The current API for La Cale returns incorrect download links containing localhost:3000 instead of the production domain la-cale.space. This prevents any torrent from being grabbed via Prowlarr.

This PR adds a replace filter to the download field to programmatically fix the URL. The tracker staff has been notified and confirmed the issue, but this hotfix is required to make the indexer functional in the meantime.

I have verified the fix locally:
- Search: Working
- Grab: Now working with the domain replacement (tested and validated).
- Validation: Passed using scripts/validate.py.

#### Issues Fixed or Closed by this PR
Fixes (no existing issue number, but fixes the "localhost" download bug for La Cale).