### PR TITLE
lacale-api: Update categories, add tmdbId support and CJK filters

### DIFF
--- a/definitions/v11/lacale-api.yml
+++ b/definitions/v11/lacale-api.yml
@@ -37,28 +37,28 @@ caps:
     - {id: t-l-phones, cat: PC/Mobile-Other, desc: "Téléphones"}
     - {id: xbox, cat: Console/XBox, desc: "Xbox"}
     # E-books
-    - {id: ebooks, cat: Books/EBook, desc: "E-books"}
-    - {id: bd, cat: Books/Comics, desc: "BD"}
+    - {id: e-books, cat: Books/EBook, desc: "E-books"}
     - {id: comics, cat: Books/Comics, desc: "Comics"}
     - {id: divers, cat: Books/Other, desc: "Divers"}
     - {id: livres, cat: Books/EBook, desc: "Livres"}
-    - {id: mangas, cat: Books/Mags, desc: "Mangas"}
+    - {id: mangas, cat: Books/Comics, desc: "Mangas"}
+    - {id: presse, cat: Books/Mags, desc: "Presse"}
     # Audio
     - {id: audio, cat: Audio, desc: "Audio"}
     - {id: audio-divers, cat: Audio/Other, desc: "Audio divers"}
     - {id: audiobooks, cat: Audio/Audiobook, desc: "Audiobooks"}
     - {id: music, cat: Audio, desc: "Musique"}
     - {id: flac, cat: Audio/Lossless, desc: "FLAC"}
-    - {id: M4A, cat: Audio, desc: "m4a"}
-    - {id: MP3, cat: Audio/MP3, desc: "mp3"}
+    - {id: m4a, cat: Audio, desc: "M4A"}
+    - {id: mp3, cat: Audio/MP3, desc: "MP3"}
     - {id: podcast, cat: Audio/Other, desc: "Podcast"}
     # XXX
     - {id: xxx, cat: XXX, desc: "XXX"}
 
   modes:
     search: [q]
-    tv-search: [q, season, ep]
-    movie-search: [q]
+    tv-search: [q, season, ep, tmdbid]
+    movie-search: [q, tmdbid]
     music-search: [q]
     book-search: [q]
 
@@ -110,10 +110,33 @@ search:
       response:
         type: json
 
+  keywordsfilters:
+    - name: trim
+    - name: re_replace
+      # Mark CJK so we can detect "CJK-only" queries
+      args: ["[\\p{IsHiragana}\\p{IsKatakana}\\p{IsCJKUnifiedIdeographs}]", "__CJK__"]
+    - name: re_replace
+      # If query is only CJK, force no-match
+      args: ["^\\s*__CJK__\\s*(?:__CJK__\\s*)*$", "nomatch_please_ignore"]
+    - name: re_replace
+      # If CJK + year only, force no-match
+      args: ["^\\s*__CJK__\\s*(?:__CJK__\\s*)*(19|20)\\d{2}\\s*$", "nomatch_please_ignore"]
+    - name: re_replace
+      # If year + CJK only, force no-match
+      args: ["^\\s*(19|20)\\d{2}\\s*__CJK__\\s*(?:__CJK__\\s*)*$", "nomatch_please_ignore"]
+    - name: re_replace
+      # Remove CJK tokens for mixed queries
+      args: ["\\b__CJK__\\b", ""]
+    - name: re_replace
+      # Normalize multiple spaces after replacements
+      args: ["\\s+", " "]
+    - name: trim
+
   inputs:
     passkey: "{{ .Config.passkey }}"
     $raw: "{{ range .Categories }}cat={{.}}&{{end}}"
     q: "{{ .Keywords }}"
+    tmdbId: "{{ .Query.TMDBID }}"
 
   rows:
     selector: $
@@ -140,6 +163,8 @@ search:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       text: "{{ .Config.sitelink }}"
+    infohash:
+      selector: infoHash
     download:
       selector: link
       filters:
@@ -154,7 +179,7 @@ search:
     leechers:
       selector: leechers
     downloadvolumefactor:
-      text: 1
+      text: 0
     uploadvolumefactor:
       text: 1
     minimumratio:


### PR DESCRIPTION
## Summary

- Update e-books category slug (ebooks to e-books)
- Remove obsolete bd category
- Add presse category
- Fix mangas category mapping (Books/Mags to Books/Comics)
- Fix m4a/mp3 slug case (was uppercase, should be lowercase)
- Add tmdbId support for movie-search and tv-search modes
- Add CJK keyword filters to prevent garbage results when Radarr/Sonarr searches with original CJK titles
- Add infohash field
- Set downloadvolumefactor to 0 (site has permanent freeleech)