### PR TITLE
gay-torrents: add Referer header to fix torrent downloads

### DIFF
--- a/definitions/v11/gay-torrents.yml
+++ b/definitions/v11/gay-torrents.yml
@@ -141,6 +141,7 @@ search:
 
   headers:
     User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.1901.203"]
+    Referer: ["https://www.gay-torrents.net/"]
 
   rows:
     selector: ul.TorrentList, ul.Torrent-List


### PR DESCRIPTION
## Summary
- Adds `Referer` header to `search.headers` for the Gay-Torrents.net indexer definition
- This fixes torrent downloads returning 0 bytes

## Problem
Gay-Torrents.net requires a `Referer` header on download requests. Without it, the server returns HTTP 200 with **0 bytes** instead of the actual `.torrent` file. This causes Prowlarr to log:

```
Downloaded for release finished (0 bytes from ...)
Invalid torrent file contents
```

The `User-Agent` header was already present in `search.headers`, but the missing `Referer` header caused every torrent grab to fail silently.

## Fix
Single line addition to `search.headers`:
```yaml
Referer: ["https://www.gay-torrents.net/"]
```

Since the Cardigann engine falls back to `search.headers` for download requests when no `download:` block is defined (`_definition.Download?.Headers ?? _definition.Search?.Headers` in `CardigannRequestGenerator.cs`), this header is automatically applied to both search and download requests.

## Testing
- Verified via direct HTTP requests that GET to the download URL **without** `Referer` returns 0 bytes
- Verified via direct HTTP requests that GET to the download URL **with** `Referer` returns a valid `.torrent` file (22,275 bytes)
- Any `Referer` value works, but using the site's own URL is the correct approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)