### PR TITLE
thepiratebay: Remove pipe OR filters that break season searche

### DIFF
--- a/definitions/v11/thepiratebay.yml
+++ b/definitions/v11/thepiratebay.yml
@@ -164,13 +164,8 @@ search:
     # replace simplified Chinese as this confuses TPB search engine #7291
     - name: re_replace
       args: ["([\\p{IsCJKUnifiedIdeographs}\\W]+)", "."]
-    # search for both S01 and Season 01
-    - name: re_replace
-      args: ["(?i)\\b(S(\\d{2,3}))\\b", "$1|\"Season.$2\""]
-    # currently, the only uploader for General Hospital puts a space between season and episode
-    # this filter searches both formats, so 'General Hospital S01E02' becomes 'General Hospital S01E02|"S01 E02"'
-    - name: re_replace
-      args: ["(?i)\\b(General\\.Hospital)\\.((S\\d{2,3})(E\\d{2,3}))\\b", "$1.$2|\"$3.$4\""]
+    # removed S01|"Season.01" pipe filter - apibay.org does not support pipe OR syntax #806
+    # removed General Hospital pipe filter - apibay.org does not support pipe OR syntax #806
     - name: tolower
 
   rows:


### PR DESCRIPTION
## Summary
- Removes two `keywordsfilters` that used pipe (`|`) as OR syntax, which apibay.org does not support
- Fixes season-level TV searches returning 0 results (e.g. "bear S02")
- The General Hospital filter had the same pipe syntax issue

Fixes #806

## Test plan
- Search for a TV show by season (e.g. "bear S02") and confirm results are returned
- Verify episode-level searches (e.g. "bear S02E03") still work
- Verify RSS feed still works

#### Indexer/Tracker


#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Issues Fixed or Closed by this PR

* Fixes #XXXX