### PR TITLE
Update Abnormal definition: switch from site scraping to API integration

### DIFF
--- a/definitions/v11/abnormal-api.yml
+++ b/definitions/v11/abnormal-api.yml
@@ -36,7 +36,7 @@ settings:
   - name: info_key
     type: info
     label: About your API key
-    default: "Find or Generate a new API Token by accessing your <a href=\"https://abn.lol/\" target=\"_blank\">Abnormal</a> account <i>My Profile</i> page. The API key provides read-only access and never expires."
+    default: "Find your API key on your <a href=\"https://abn.lol/User/Parameters\" target=\"_blank\">Parameters</a> page. The API key is read-only and never expires."
   - name: freeleech
     type: checkbox
     label: Search freeleech only


### PR DESCRIPTION
#### Abnormal

#### Description
The site-scraping definition for Abnormal no longer works because the Abnormal staff have blocked Prowlarr requests to reduce site load. An official API has been created to provide a cleaner, supported integration, so the old scraper has been removed and replaced with an API-based definition.

#### Changes
Deleted: definitions/v11/abnormal.yml
Added: definitions/v11/abnormal-api.yml