### PR TITLE
fix: rockethd change single_file_release_use_filename default to false

### DIFF
--- a/definitions/v11/rockethd.yml
+++ b/definitions/v11/rockethd.yml
@@ -39,7 +39,7 @@ settings:
   - name: single_file_release_use_filename
     type: checkbox
     label: Use filename as title for single file releases
-    default: true
+    default: false
   - name: sort
     type: select
     label: Sort requested from site


### PR DESCRIPTION
## RocketHD: Change `single_file_release_use_filename` default to `false`

RocketHD uses enriched release names that already contain all relevant metadata (resolution, codec, group, etc.). Since not all individual filenames carry the same level of detail, defaulting to the release name provides more consistent and complete results for Sonarr/Radarr matching.

This changes the `single_file_release_use_filename` setting default from `true` to `false`. Users who prefer filenames can still enable the option manually.