### PR TITLE
Fix: Jackett change to non-yml .github file causing removal of file

### DIFF
--- a/scripts/indexer-sync-v2.sh
+++ b/scripts/indexer-sync-v2.sh
@@ -708,7 +708,7 @@ resolve_conflicts() {
 
     readme_conflicts=$(echo "$conflicted_files" | grep -E '^README\.md$' || true)
     # Explicitly exclude important repository files and schema files from nonyml conflicts
-    nonyml_conflicts=$(echo "$conflicted_files" | grep -E "$CONFLICTS_NONYML_EXTENSIONS" | grep -v -E '^(README\.md|CONTRIBUTING\.md|LICENSE\.md)$' | grep -v 'schema\.json$' || true)
+    nonyml_conflicts=$(echo "$conflicted_files" | grep -E "$CONFLICTS_NONYML_EXTENSIONS" | grep -v -E '^(README\.md|CONTRIBUTING\.md|LICENSE\.md)$' | grep -v 'schema\.json$' | grep -v -E '^\.github' || true)
     yml_conflicts=$(echo "$conflicted_files" | grep -E '\.ya?ml$' | grep -v -E '^\.github' || true)
     schema_conflicts=$(echo "$conflicted_files" | grep -E '\.schema\.json$' || true)
     github_conflicts=$(echo "$conflicted_files" | grep -E '^\.github' || true)


### PR DESCRIPTION
Fix: Jackett change to non-yml .github file causing removal of file

Jackett changed their pull request template in https://github.com/Jackett/Jackett/commit/c76c8e363b5ac4b5aafee3f801c52207e35480cd which caused the indexer sync script to want to remove our copy completely. This removes it from being handled by the non-yml conflicts logic and instead handled only by the .github logic.