### PR TITLE
BJ-Share: Fix rows selector, season filtering and anime support

### DIFF
--- a/definitions/v11/bjshare.yml
+++ b/definitions/v11/bjshare.yml
@@ -65,7 +65,7 @@ search:
 
   inputs:
     $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
-    searchstr: "{{ .Keywords }}"
+    searchstr: "{{ .Query.Keywords }}"
     freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
 
   keywordsfilters:
@@ -73,11 +73,11 @@ search:
       args: ["(S[0-9]+E[0-9]+|S[0-9]+)", ""] # remove SXXEXX or SXX from search
 
   rows:
-    # If the category is a TV show/Anime, there's a necessity to filter the results by season/episode to not show all of them
     selector: "table.torrent_table > tbody > tr:not(tr.colhead).group,
-              table.torrent_table tbody tr:not(tr.colhead):contains('{{ .Query.Episode }}')"
-    filters:
-      - name: andmatch
+               table.torrent_table > tbody > tr.group_torrent,
+               table.torrent_table > tbody > tr.torrent"
+#    filters:
+#      - name: andmatch
 
   fields:
     download:

--- a/definitions/v11/bjshare.yml
+++ b/definitions/v11/bjshare.yml
@@ -68,17 +68,10 @@ search:
     searchstr: "{{ .Query.Keywords }}"
     freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
 
-  keywordsfilters:
-    - name: re_replace
-      args: ["(S[0-9]+E[0-9]+|S[0-9]+)", ""] # remove SXXEXX or SXX from search
-
   rows:
     selector: "table.torrent_table > tbody > tr:not(tr.colhead).group,
                table.torrent_table > tbody > tr.group_torrent,
                table.torrent_table > tbody > tr.torrent"
-#    filters:
-#      - name: andmatch
-
   fields:
     download:
       selector: a[title="Baixar"]

--- a/definitions/v11/bjshare.yml
+++ b/definitions/v11/bjshare.yml
@@ -72,6 +72,8 @@ search:
     selector: "table.torrent_table > tbody > tr:not(tr.colhead).group,
                table.torrent_table > tbody > tr.group_torrent,
                table.torrent_table > tbody > tr.torrent"
+
+
   fields:
     download:
       selector: a[title="Baixar"]
@@ -86,6 +88,8 @@ search:
     _info: # example [MKV / x265 / WEB-DL / Legendado / 4K / Free]
       text: "{{ if .Result._singleTorrentInfo }}{{.Result._singleTorrentInfo}}{{ else }}{{.Result._multipleTorrentInfo}}{{ end }}"
       filters:
+        - name: re_replace
+          args: ["^[^\\[].*", ""]  # discard if not starting with [ (e.g. "S04", "S05E02")
         - name: replace
           args: ["Full HD", "1080p"]
         - name: replace
@@ -98,6 +102,10 @@ search:
           args: ["/ HD /", "720p"]
         - name: replace
           args: ["/ Free", ""]
+        - name: re_replace
+          args: ["/ Porn Kings", ""]
+        - name: re_replace
+          args: [" INTERNAL", ""]
         - name: re_replace
           args: ["[\\[\\]]+", ""]
 
@@ -127,11 +135,19 @@ search:
         - name: re_replace
           args: ["\\[[0-9]*\\].*", ""] # Removes the year and everything after
         - name: re_replace
-          args: ["(.*)\\[(!?[^/]*?)\\]", "$2"]   # Parse only en-us title, when available
-        - name: append
-          args: "{{ .Result._year }}"
+          args: ["(.+)\\[([^0-9][^/]*?)\\]", "$2"]   # Parse only en-us title, when available (skip year-only brackets)
+        - name: re_replace
+          args: ["\\s*-?\\s*$", ""]
+        - name: re_replace
+          args: [" - (S\\d+)", " $1"]  # remove dash before season tag
         - name: append
           args: " {{ .Result._info }}"
+        - name: re_replace
+          args: ["\\s+", " "]
+        - name: re_replace
+          args: ["\\s+$", ""]
+        - name: append
+          args: " {{ .Result._year }}"
 
     title_Other:
       # Only remove brackets
@@ -168,6 +184,18 @@ search:
                    (or eq .Result.category_details \"8\")
                    (or (eq .Result.category_details \"13\") (eq .Result.category_details \"6\")))))))
              }}{{.Result.title_MovieTV}}{{ else }}{{.Result.title_Other}}{{ end }}"
+
+    season:
+      text: "{{ .Result._rawTitle }}"
+      filters:
+        - name: regexp
+          args: ".* - S(\\d+)"
+
+    episode:
+      text: "{{ .Result._rawTitle }}"
+      filters:
+        - name: regexp
+          args: ".* - S\\d+E(\\d+)"
 
     size:
       selector: td:nth-last-child(4)

--- a/definitions/v11/bjshare.yml
+++ b/definitions/v11/bjshare.yml
@@ -65,14 +65,15 @@ search:
 
   inputs:
     $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
-    searchstr: "{{ .Query.Keywords }}"
+    searchstr: "{{ .Keywords }}"
     freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
 
   rows:
-    selector: "table.torrent_table > tbody > tr:not(tr.colhead).group,
-               table.torrent_table > tbody > tr.group_torrent,
+    selector: "table.torrent_table > tbody > tr.group,
+               table.torrent_table > tbody > tr.group_torrent.edition_0,
                table.torrent_table > tbody > tr.torrent"
-
+    filters:
+      - name: andmatch
 
   fields:
     download:
@@ -83,13 +84,11 @@ search:
       selector: div.torrent_info
 
     _multipleTorrentInfo:
-      selector: a[href^="torrents.php?id="]
+      selector: "a[href^='torrents.php?id=']:not(.tooltip)"
 
     _info: # example [MKV / x265 / WEB-DL / Legendado / 4K / Free]
       text: "{{ if .Result._singleTorrentInfo }}{{.Result._singleTorrentInfo}}{{ else }}{{.Result._multipleTorrentInfo}}{{ end }}"
       filters:
-        - name: re_replace
-          args: ["^[^\\[].*", ""]  # discard if not starting with [ (e.g. "S04", "S05E02")
         - name: replace
           args: ["Full HD", "1080p"]
         - name: replace
@@ -103,25 +102,21 @@ search:
         - name: replace
           args: ["/ Free", ""]
         - name: re_replace
-          args: ["/ Porn Kings", ""]
-        - name: re_replace
-          args: [" INTERNAL", ""]
-        - name: re_replace
           args: ["[\\[\\]]+", ""]
 
     _rawTitle:
-      selector: div.group_info
+      selector: "div.group_info"
       filters:
         - name: re_replace
-          args: ["(\n.*)", ""] # remove everything after newline
+          args: ["(\n.*)", ""] # remove everything after newline (cuts bookmark/tags)
         - name: re_replace
-          args: ["  |\t", ""] # remove double space and tabs
+          args: ["  |\t", ""] # remove double spaces and tabs
 
     _year:
-      text: "{{ .Result._rawTitle }}"
+      selector: "div.group_info"
       filters:
         - name: regexp
-          args: "\\[([0-9]*)\\]"
+          args: "\\[([0-9]{4})\\]"
 
     details:
       selector: a[href^="torrents.php?id="]:not(.tooltip)
@@ -133,21 +128,21 @@ search:
       text: "{{ .Result._rawTitle }}"
       filters:
         - name: re_replace
-          args: ["\\[[0-9]*\\].*", ""] # Removes the year and everything after
+          args: ["\\[[0-9]*\\].*", ""]
         - name: re_replace
-          args: ["(.+)\\[([^0-9][^/]*?)\\]", "$2"]   # Parse only en-us title, when available (skip year-only brackets)
+          args: ["(.+)\\[([^0-9][^/]*?)\\]", "$2"]
         - name: re_replace
           args: ["\\s*-?\\s*$", ""]
         - name: re_replace
-          args: [" - (S\\d+)", " $1"]  # remove dash before season tag
+          args: [" - (S\\d+)", " $1"]
         - name: append
-          args: " {{ .Result._info }}"
+          args: " {{ .Result._year }}"    # ← ano ANTES do _info
+        - name: append
+          args: " {{ .Result._info }}"    # ← _info por último
         - name: re_replace
           args: ["\\s+", " "]
         - name: re_replace
           args: ["\\s+$", ""]
-        - name: append
-          args: " {{ .Result._year }}"
 
     title_Other:
       # Only remove brackets
@@ -164,7 +159,11 @@ search:
         - name: re_replace
           args: ["\\[[0-9]*\\].*", ""] # Removes the year and everything after
         - name: re_replace
-          args: ["(.*)\\[(!?[^/]*?)\\]", "$2"]   # Parse only en-us title, when available
+          args: ["(.+)\\[([^0-9][^/]*?)\\]", "$2"]   # Parse only en-us title, when available (skip year-only brackets)
+        - name: re_replace
+          args: ["\\s*-?\\s*$", ""]
+        - name: re_replace
+          args: [" - (S\\d+)", " $1"]  # remove dash before season tag
 
     category_details:
       selector: td.cats_col > a
@@ -181,10 +180,40 @@ search:
                     or (eq .Result.category_details \"1\")
                    (or (eq .Result.category_details \"2\")  (or (eq .Result.category_details \"14\")
                    (or (eq .Result.category_details \"16\") (or (eq .Result.category_details \"17\")
-                   (or eq .Result.category_details \"8\")
+                   (or (eq .Result.category_details \"8\")
                    (or (eq .Result.category_details \"13\") (eq .Result.category_details \"6\")))))))
              }}{{.Result.title_MovieTV}}{{ else }}{{.Result.title_Other}}{{ end }}"
+    date:
+      selector: td.nobr span.time
+      attribute: title
+      filters:
+        - name: append
+          args: " +00:00" # GMT
+        - name: dateparse
+          args: "MMM dd yyyy, HH:mm zzz"    
 
+    size:
+      selector: "td.number_column.nobr"
+      optional: true
+    grabs:
+      selector: "td.number_column:nth-child(5)"
+      optional: true
+    seeders:
+      selector: "td.number_column:nth-last-child(2)"
+    leechers:
+      selector: "td.number_column:nth-last-child(1)"
+    downloadvolumefactor:
+      case:
+        strong[title*="Free"]: 0
+        "*": 1
+    uploadvolumefactor:
+      text: 1
+    minimumratio:
+      text: 1.0
+    minimumseedtime:
+      # 7 days (as seconds = 7 x 24 x 60 x 60)
+      text: 604800
+    
     season:
       text: "{{ .Result._rawTitle }}"
       filters:
@@ -197,22 +226,3 @@ search:
         - name: regexp
           args: ".* - S\\d+E(\\d+)"
 
-    size:
-      selector: td:nth-last-child(4)
-    grabs:
-      selector: td:nth-last-child(3)
-    seeders:
-      selector: td:nth-last-child(2)
-    leechers:
-      selector: td:nth-last-child(1)
-    downloadvolumefactor:
-      case:
-        strong[title*="Free"]: 0
-        "*": 1
-    uploadvolumefactor:
-      text: 1
-    minimumratio:
-      text: 1.0
-    minimumseedtime:
-      # 7 days (as seconds = 7 x 24 x 60 x 60)
-      text: 604800

--- a/definitions/v11/bjshare.yml
+++ b/definitions/v11/bjshare.yml
@@ -68,6 +68,10 @@ search:
     searchstr: "{{ .Keywords }}"
     freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
 
+  keywordsfilters:
+    - name: re_replace
+      args: ["\\s*S\\d{2}(E\\d{2})?$", ""]
+
   rows:
     selector: "table.torrent_table > tbody > tr.group,
                table.torrent_table > tbody > tr.group_torrent.edition_0,
@@ -80,14 +84,37 @@ search:
       selector: a[title="Baixar"]
       attribute: href
 
-    _singleTorrentInfo:
+    # data-torrentname: nome real do arquivo/diretório — disponível em tr.group via div.torrent_info
+    # tr.group_torrent.edition_0 não tem div.torrent_info, fica vazio e cai no fallback
+    _torrentname:
       selector: div.torrent_info
+      attribute: data-torrentname
+
+    _imdbid:
+      selector: div.torrent_info
+      attribute: data-imdbid
+
+    _year:
+      selector: div.torrent_info
+      attribute: data-year
+
+    # fallback para tr.group_torrent.edition_0 que não tem div.torrent_info
+    _rawTitle:
+      selector: "div.group_info"
+      filters:
+        - name: re_replace
+          args: ["(\n.*)", ""]
+        - name: re_replace
+          args: ["  |\t", ""]
+
+    _rawYear:
+      selector: "div.group_info"
+      filters:
+        - name: regexp
+          args: "\\[([0-9]{4})\\]"
 
     _multipleTorrentInfo:
       selector: "a[href^='torrents.php?id=']:not(.tooltip)"
-
-    _info: # example [MKV / x265 / WEB-DL / Legendado / 4K / Free]
-      text: "{{ if .Result._singleTorrentInfo }}{{.Result._singleTorrentInfo}}{{ else }}{{.Result._multipleTorrentInfo}}{{ end }}"
       filters:
         - name: replace
           args: ["Full HD", "1080p"]
@@ -104,66 +131,36 @@ search:
         - name: re_replace
           args: ["[\\[\\]]+", ""]
 
-    _rawTitle:
-      selector: "div.group_info"
-      filters:
-        - name: re_replace
-          args: ["(\n.*)", ""] # remove everything after newline (cuts bookmark/tags)
-        - name: re_replace
-          args: ["  |\t", ""] # remove double spaces and tabs
-
-    _year:
-      selector: "div.group_info"
-      filters:
-        - name: regexp
-          args: "\\[([0-9]{4})\\]"
-
-    details:
-      selector: a[href^="torrents.php?id="]:not(.tooltip)
-      attribute: href
-
-    title_MovieTV: # Movie and TV Format
-      # Title defined as:
-        # PT-BR/Japanese title [en-US title] [year]
+    # título do grupo para tr.group_torrent (herda via Cardigann do tr.group pai)
+    _fallbackTitle:
       text: "{{ .Result._rawTitle }}"
       filters:
         - name: re_replace
           args: ["\\[[0-9]*\\].*", ""]
         - name: re_replace
-          args: ["(.+)\\[([^0-9][^/]*?)\\]", "$2"]
+          args: ["(.+)\\[([^0-9][^\\]/]*?)(?:/[^\\]]*?)?\\]", "$2"]
         - name: re_replace
           args: ["\\s*-?\\s*$", ""]
         - name: re_replace
           args: [" - (S\\d+)", " $1"]
         - name: append
-          args: " {{ .Result._year }}"    # ← ano ANTES do _info
+          args: " {{ .Result._rawYear }}"
         - name: append
-          args: " {{ .Result._info }}"    # ← _info por último
+          args: " {{ .Result._multipleTorrentInfo }}"
         - name: re_replace
           args: ["\\s+", " "]
         - name: re_replace
           args: ["\\s+$", ""]
 
-    title_Other:
-      # Only remove brackets
-      text: "{{ .Result._rawTitle }}"
-      filters:
-        - name: re_replace
-          args: ["\\[|\\]", " "] # Remove Brackets
+    details:
+      selector: a[href^="torrents.php?id="]:not(.tooltip)
+      attribute: href
 
-    title_details:
-      # Title defined as:
-        # PT-BR/Japanese title [en-US title] [year]
-      text: "{{ .Result._rawTitle }}"
+    imdbid:
+      text: "{{ .Result._imdbid }}"
       filters:
-        - name: re_replace
-          args: ["\\[[0-9]*\\].*", ""] # Removes the year and everything after
-        - name: re_replace
-          args: ["(.+)\\[([^0-9][^/]*?)\\]", "$2"]   # Parse only en-us title, when available (skip year-only brackets)
-        - name: re_replace
-          args: ["\\s*-?\\s*$", ""]
-        - name: re_replace
-          args: [" - (S\\d+)", " $1"]  # remove dash before season tag
+        - name: regexp
+          args: "(tt\\d+)"
 
     category_details:
       selector: td.cats_col > a
@@ -175,14 +172,10 @@ search:
     category:
       text: "{{ .Result.category_details }}"
 
+    # usa data-torrentname quando disponível (tr.group); cai no fallback para tr.group_torrent
     title:
-      text: "{{ if
-                    or (eq .Result.category_details \"1\")
-                   (or (eq .Result.category_details \"2\")  (or (eq .Result.category_details \"14\")
-                   (or (eq .Result.category_details \"16\") (or (eq .Result.category_details \"17\")
-                   (or (eq .Result.category_details \"8\")
-                   (or (eq .Result.category_details \"13\") (eq .Result.category_details \"6\")))))))
-             }}{{.Result.title_MovieTV}}{{ else }}{{.Result.title_Other}}{{ end }}"
+      text: "{{ if .Result._torrentname }}{{ .Result._torrentname }}{{ else }}{{ .Result._fallbackTitle }}{{ end }}"
+
     date:
       selector: td.nobr span.time
       attribute: title
@@ -190,10 +183,11 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "MMM dd yyyy, HH:mm zzz"    
+          args: "MMM dd yyyy, HH:mm zzz"
 
     size:
-      selector: "td.number_column.nobr"
+      # tr.group / tr.torrent: size at position 6 | tr.group_torrent: colspan td counts as 1, size at position 4
+      selector: "td:nth-child(6).number_column.nobr, td:nth-child(4).number_column.nobr"
       optional: true
     grabs:
       selector: "td.number_column:nth-child(5)"
@@ -204,7 +198,7 @@ search:
       selector: "td.number_column:nth-last-child(1)"
     downloadvolumefactor:
       case:
-        strong[title*="Free"]: 0
+        "strong.torrent_label.bjtooltip.free": 0
         "*": 1
     uploadvolumefactor:
       text: 1
@@ -213,16 +207,16 @@ search:
     minimumseedtime:
       # 7 days (as seconds = 7 x 24 x 60 x 60)
       text: 604800
-    
+
     season:
-      text: "{{ .Result._rawTitle }}"
+      text: "{{ if .Result._torrentname }}{{ .Result._torrentname }}{{ else }}{{ .Result._rawTitle }}{{ end }}"
       filters:
         - name: regexp
-          args: ".* - S(\\d+)"
+          args: "[Ss](\\d{2})[Ee]?\\d*"
 
     episode:
-      text: "{{ .Result._rawTitle }}"
+      text: "{{ if .Result._torrentname }}{{ .Result._torrentname }}{{ else }}{{ .Result._rawTitle }}{{ end }}"
       filters:
         - name: regexp
-          args: ".* - S\\d+E(\\d+)"
+          args: "[Ss]\\d{2}[Ee](\\d{2})"
 


### PR DESCRIPTION
BJ-Share changed their site HTML structure, breaking torrent results in Sonarr/Radarr.

### Changes

**1. New HTML table structure**
The torrent table now uses multiple row types:
- `tr.group` → season pack rows
- `tr.group_torrent` → individual torrent rows (TV shows)
- `tr.torrent` → anime torrent rows

The old selector only matched `tr.group`, missing all individual torrents.

**2. Season filtering broken by keywordsfilters**
`keywordsfilters` strips `S01`/`S02` from `.Keywords`, so BJ-Share received
no season info and returned mixed results from all seasons.

Using `.Query.Keywords` (raw, before filters) preserves the season tag,
allowing BJ-Share to filter results natively.

### Testing
- `The Last of Us S01` → 12 results, all S01 ✅
- `The Last of Us S02` → 5 results, all S02 ✅
- `For All Mankind S05E01` → 3 results ✅
- `Daemons of the Shadow Realm` (anime) → 1 result ✅
