### PR TITLE
jackett indexers as of caa73e00303648cdbefbb82987776e3eb9b740e0 [2026-04-18T16:41]

### DIFF
--- a/definitions/v11/coastalcrew.yml
+++ b/definitions/v11/coastalcrew.yml
@@ -51,6 +51,8 @@ caps:
     - {id: 11, cat: PC/Mobile-Other, desc: "App Other"}
     - {id: 10, cat: PC/Mac, desc: "App Mac"}
 
+    - {id: 143, cat: Console/PS4, desc: "Game PS4/PS5"}
+    - {id: 144, cat: Console/Other, desc: "Game Nintendo Switch"}
     - {id: 16, cat: Console, desc: "Game Misc"}
     - {id: 17, cat: PC/Games, desc: "Game PC"}
     - {id: 18, cat: Console/PS3, desc: "Game PS2"}

--- a/definitions/v11/hdtorrents.yml
+++ b/definitions/v11/hdtorrents.yml
@@ -152,8 +152,12 @@ search:
       attribute: href
     genre:
       selector: td:nth-child(3) span
+    _internal:
+      case:
+        img[src$="internal.png"]: "{{ .True }}"
+        "*": "{{ .False }}"
     description:
-      text: "{{ .Result.genre }}"
+      text: "{{ if .Result._internal }}Internal{{ else }}{{ end }}{{ if and .Result._internal .Result.genre }} | {{ else }}{{ end }}{{ .Result.genre }}"
     date:
       # auto adjusted by site account profile
       selector: td:nth-child(7)

--- a/definitions/v11/magnetcat.yml
+++ b/definitions/v11/magnetcat.yml
@@ -9,15 +9,12 @@ encoding: UTF-8
 links:
   - https://magnetcatcat.com/
   - https://clmclm.com/
-  - https://www.8800561.xyz/
-  - https://www.8800562.xyz/
-  - https://www.8800563.xyz/
   - https://www.8800564.xyz/
+  - https://www.8800565.xyz/
+  - https://www.8800566.xyz/
+  - https://www.8800567.xyz/
 legacylinks:
   - https://www.clm472.sbs/
-  - https://www.8800543.xyz/
-  - https://www.8800544.xyz/
-  - https://www.8800545.xyz/
   - https://www.8800546.xyz/
   - https://www.8800547.xyz/
   - https://www.8800548.xyz/
@@ -31,6 +28,9 @@ legacylinks:
   - https://www.8800558.xyz/
   - https://www.8800559.xyz/
   - https://www.8800560.xyz/
+  - https://www.8800561.xyz/
+  - https://www.8800562.xyz/
+  - https://www.8800563.xyz/
 
 caps:
   categorymappings:

--- a/definitions/v11/midnightscene.yml
+++ b/definitions/v11/midnightscene.yml
@@ -1,0 +1,193 @@
+---
+id: midnightscene
+name: MidnightScene
+description: "MidnightScene is a Private Torrent Tracker for MOVIES / TV / GENERAL"
+language: en-US
+type: private
+encoding: UTF-8
+links:
+  - https://midnightscene.cc/
+
+caps:
+  categorymappings:
+    - {id: 1, cat: Movies, desc: "Movies"}
+    - {id: 2, cat: TV, desc: "TV"}
+    - {id: 3, cat: Audio, desc: "Music"}
+    - {id: 4, cat: Console, desc: "Games"}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid, tvdbid, tmdbid]
+    movie-search: [q, imdbid, tmdbid]
+    music-search: [q]
+
+settings:
+  - name: apikey
+    type: text
+    label: APIKey
+  - name: info_key
+    type: info
+    label: About your API key
+    default: "Find or Generate a new API Token by accessing your <a href=\"https://midnightscene.cc/\" target=\"_blank\">MidnightScene</a> account <i>My Settings</i> page and clicking on the <b>API Key</b> tab."
+  - name: freeleech
+    type: checkbox
+    label: Search freeleech only
+    default: false
+  - name: single_file_release_use_filename
+    type: checkbox
+    label: Use filename as title for single file releases
+    default: true
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: created_at
+    options:
+      created_at: created
+      seeders: seeders
+      size: size
+      name: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
+  - name: info_activity
+    type: info
+    label: Account Inactivity
+    default: "Members must log into the site at minimum every 90 days or their account will be disabled for inactivity."
+
+login:
+  path: api/torrents
+  method: get
+  error:
+    - selector: a[href*="/login"]
+      message:
+        text: "The API key was not accepted by {{ .Config.sitelink }}."
+    - selector: :root:contains("Account is Banned")
+
+search:
+  paths:
+    # https://hdinnovations.github.io/UNIT3D/torrent_api.html
+    # https://github.com/HDInnovations/UNIT3D/blob/master/app/Http/Controllers/API/TorrentController.php#L657
+    - path: api/torrents/filter
+      response:
+        type: json
+
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
+  inputs:
+  # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
+    $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
+    name: "{{ .Keywords }}"
+    seasonNumber: "{{ .Query.Season }}"
+    episodeNumber: "{{ .Query.Ep }}"
+    imdbId: "{{ .Query.IMDBIDShort }}"
+    tmdbId: "{{ .Query.TMDBID }}"
+    tvdbId: "{{ .Query.TVDBID }}"
+    "free[]": "{{ if .Config.freeleech }}100{{ else }}{{ end }}"
+    sortField: "{{ .Config.sort }}"
+    sortDirection: "{{ .Config.type }}"
+    perPage: 100
+
+  keywordsfilters:
+    - name: re_replace
+      args: ["\\.", " "]
+
+  rows:
+    selector: data
+    attribute: attributes
+
+  fields:
+    category:
+      selector: category_id
+    title_optional:
+      selector: name
+    title_filename:
+      selector: "files[0].name"
+      optional: true
+    files:
+      selector: num_file
+    title:
+      text: "{{ if and (.Config.single_file_release_use_filename) (eq .Result.files \"1\") (.Result.title_filename) }}{{ .Result.title_filename }}{{ else }}{{ .Result.title_optional }}{{ end }}"
+    details:
+      selector: details_link
+    download:
+      selector: download_link
+    poster:
+      selector: meta.poster
+      filters:
+        - name: replace
+          args: ["https://via.placeholder.com/90x135", ""]
+    imdbid:
+      selector: imdb_id
+    tmdbid:
+      selector: tmdb_id
+    tvdbid:
+      selector: tvdb_id
+    genre:
+      selector: meta.genres
+      filters:
+        - name: re_replace
+          args: ["(?i)(Science Fiction)", "Science_Fiction"]
+        - name: re_replace
+          args: ["(?i)(TV Movie)", "TV_Movie"]
+        - name: replace
+          args: [" & ", "_&_"]
+    _internal:
+      selector: internal
+      case:
+        False: "{{ .False }}"
+        True: "{{ .True }}"
+    description:
+      text: "{{ if .Result._internal }}Internal{{ else }}{{ end }}{{ if and .Result._internal .Result.genre }} | {{ else }}{{ end }}{{ .Result.genre }}"
+    seeders:
+      selector: seeders
+    leechers:
+      selector: leechers
+    grabs:
+      selector: times_completed
+    date:
+      # "created_at": "2021-10-18T00:34:50.000000Z" is returned by Newtonsoft.Json.Linq as 18/10/2021 00:34:50
+      selector: created_at
+      filters:
+        - name: append
+          args: " +00:00" # GMT
+        - name: dateparse
+          args: "MM/dd/yyyy HH:mm:ss zzz"
+    size:
+      selector: size
+    _featured:
+      selector: featured
+      case:
+        False: "{{ .False }}"
+        True: "{{ .True }}"
+    downloadvolumefactor_freeleech:
+      # api returns 0%, 25%, 50%, 75%, 100%
+      selector: freeleech
+      case:
+        0%: 1 # not free
+        25%: 0.75
+        50%: 0.5
+        75%: 0.25
+        100%: 0 # freeleech
+        "*": 0 # catch errors
+    downloadvolumefactor:
+      text: "{{ if .Result._featured }}0{{ else }}{{ .Result.downloadvolumefactor_freeleech }}{{ end }}"
+    uploadvolumefactor_double_upload:
+      # api returns False, True
+      selector: double_upload
+      case:
+        False: 1 # normal
+        True: 2 # double
+    uploadvolumefactor:
+      text: "{{ if .Result._featured }}2{{ else }}{{ .Result.uploadvolumefactor_double_upload }}{{ end }}"
+# global MR is 0.4 but torrents must be seeded for 2 days regardless of ratio
+#    minimumratio:
+#      text: 0.4
+    minimumseedtime:
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
+# json UNIT3D 9.2.0

--- a/definitions/v11/torrentqq.yml
+++ b/definitions/v11/torrentqq.yml
@@ -7,9 +7,8 @@ type: public
 encoding: UTF-8
 followredirect: true
 links:
-  - https://torrentqq415.com/
+  - https://torrentqq416.com/
 legacylinks:
-  - https://torrentqq400.com/
   - https://torrentqq401.com/
   - https://torrentqq402.com/
   - https://torrentqq403.com/
@@ -25,6 +24,7 @@ legacylinks:
   - https://torrentqq412.com/
   - https://torrentqq413.com/
   - https://torrentqq414.com/
+  - https://torrentqq415.com/
 
 caps:
   categorymappings:


### PR DESCRIPTION
Added Indexers: definitions/v11/midnightscene.yml

Modified Indexers:
definitions/v11/coastalcrew.yml
definitions/v11/hdtorrents.yml
definitions/v11/magnetcat.yml
definitions/v11/torrentqq.yml

#### Indexer/Tracker


#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Issues Fixed or Closed by this PR

error when testing connection:
> Unable to connect to indexer. Redirected to https://torrentqq416.com/torrent/newest.html from indexer request

note: added only midnightscene. not adding other missing definitions because they were deliberately removed  https://github.com/Prowlarr/Indexers/issues/370