### PR TITLE
bjshare: fix tv-search failing for season packs and episodes

### DIFF
--- a/definitions/v11/bjshare.yml
+++ b/definitions/v11/bjshare.yml
@@ -70,14 +70,16 @@ search:
 
   keywordsfilters:
     - name: re_replace
-      args: ["(S[0-9]+E[0-9]+|S[0-9]+)", ""] # remove SXXEXX or SXX from search
+      args: ["(S[0-9]+E[0-9]+|S[0-9]+)", ""]
+    - name: re_replace
+      args: ["\\s*\\(\\d{4}\\)\\s*", " "]
+    - name: re_replace
+      args: ["\\s+", " "]
+    - name: trim
 
   rows:
-    # If the category is a TV show/Anime, there's a necessity to filter the results by season/episode to not show all of them
     selector: "table.torrent_table > tbody > tr:not(tr.colhead).group,
               table.torrent_table tbody tr:not(tr.colhead):contains('{{ .Query.Episode }}')"
-    filters:
-      - name: andmatch
 
   fields:
     download:


### PR DESCRIPTION
## Summary

Fixes two issues that prevent Sonarr/Radarr from finding releases when searching BJ-Share via Torznab:

1. **Year disambiguation breaks search** — When *arr apps send queries like `Tracker (2024) S03`, the `keywordsfilters` strip `S03` but leave `(2024)`. BJ-Share's search doesn't handle parenthesized years and returns no results. Added filters to strip the year and normalize whitespace.

2. **`andmatch` rejects valid results due to PT-BR titles** — BJ-Share groups use PT-BR titles (e.g. "Demolidor" instead of "Daredevil"). When `andmatch` compares the English keywords from Sonarr against the extracted PT-BR title, it fails. The CSS `:contains('{{ .Query.Episode }}')` selector already filters rows by season/episode correctly, making `andmatch` redundant.

## Changes

- Added `keywordsfilters` to strip `(YYYY)` year patterns and normalize whitespace
- Removed `andmatch` row filter (CSS `:contains()` handles filtering)

## Testing

Tested with BJ-Share indexer configured in Prowlarr, searching from Sonarr for:
- Season packs (e.g. `tvsearch` with `season=3`) — previously returned 0 results, now returns correct season pack and episode torrents
- Individual episodes (e.g. `S03E10`) — continues to work correctly
- General text searches — unaffected

Fixes #334