### PR TITLE
torrentqq: bump domain

### DIFF
--- a/definitions/v11/torrentqq.yml
+++ b/definitions/v11/torrentqq.yml
@@ -7,7 +7,7 @@ type: public
 encoding: UTF-8
 followredirect: true
 links:
-  - https://torrentqq416.com/
+  - https://torrentqq417.com/
 legacylinks:
   - https://torrentqq401.com/
   - https://torrentqq402.com/
@@ -25,6 +25,7 @@ legacylinks:
   - https://torrentqq413.com/
   - https://torrentqq414.com/
   - https://torrentqq415.com/
+  - https://torrentqq416.com/
 
 caps:
   categorymappings:


### PR DESCRIPTION
#### Indexer/Tracker

Torrent QQ https://torrentqq417.com/

#### Description

Torrent QQ (토렌트큐큐) changes its domain very frequently, so it requires to update the URL frequently.

This is a copy of upstream PR https://github.com/Jackett/Jackett/pull/16767

#### Issues Fixed or Closed by this PR

<img width="518" height="350" alt="image" src="https://github.com/user-attachments/assets/ff9b8a85-7fdd-46c0-a034-b4293b355ae1" />

looking forward to a speedy resolution