### PR TITLE
improve(blutopia-api): add TV/Anime category mapping

### DIFF
--- a/definitions/v11/blutopia-api.yml
+++ b/definitions/v11/blutopia-api.yml
@@ -15,6 +15,7 @@ caps:
     - {id: 1, cat: Movies, desc: "Movie"}
     - {id: 8, cat: Other, desc: "Other"}
     - {id: 2, cat: TV, desc: "TV Show"}
+    - {id: 2, cat: TV/Anime, desc: "TV Show (Anime)"}
     - {id: 3, cat: Movies/Other, desc: "FANRES"}
     - {id: 5, cat: Movies/Other, desc: "Trailer"}
     - {id: 9, cat: Audio/Video, desc: "Live Concert"}


### PR DESCRIPTION
#### Indexer/Tracker
Blutopia (BLU)

#### Description
BLU has no separate internal anime category, anime releases live alongside other TV under the indexer's internal `cat=2` so this mapping is additive: both Newznab 5000 (TV) and 5070 (TV/Anime) now route to the same internal endpoint.

Without 5070 in capabilities, Newznab consumers (Sonarr's anime search, etc.) that fan out by category 5070 get zero results from BLU even though the anime content is right there and reachable via 5000.

Verified empirically against a live Blutopia instance with both the bundled and patched defs:

| Title         | bundled cat=5070 | patched cat=5070 | patched cat=5000 |
|---------------|-----------------:|-----------------:|-----------------:|
| Dandadan      |                0 |               10 |               10 |
| Demon Slayer  |                0 |               31 |               31 |
| Cowboy Bebop  |                0 |               22 |               22 |

(Counts identical between 5070 and 5000 on the patched def confirm the mapping just exposes content already accessible via TV; nothing is duplicated.)
