### PR TITLE
fix: Remove non existing upstream trackers from the blocklist

### DIFF
--- a/scripts/blocklist.txt
+++ b/scripts/blocklist.txt
@@ -1,23 +1,10 @@
 # Blocklist for problematic indexers
 # Format: filename.yml (without path)
 
-# Union/YGG related
-uniongang.yml
-uniongangcookie.yml
-ygg-api.yml
-yggtorrent.yml
-yggcookie.yml
-yggtorrent-turbo.yml
-yggcookie-turbo.yml
 u2p.yml
-
-sharewood.yml
 anirena.yml
-torrentgalaxy.yml
-scenelinks.yml
 therarbg.yml
 ildragonero.yml
 rutracker-ru.yml
 magnetz.yml
-tvchaosuk.yml
 fearnopeer.yml


### PR DESCRIPTION
#### Description
Remove non-existing trackers from the blocklist.txt file.
YGG has disappeared, so have many other trackers that were in the block list. No reason to keep the legacy around.