### PR TITLE
fix(brasiltracker): update column offsets for size, grabs and stats

### DIFF
--- a/definitions/v11/brasiltracker.yml
+++ b/definitions/v11/brasiltracker.yml
@@ -132,13 +132,13 @@ search:
         - name: dateparse
           args: "MMM d yyyy, HH:mm zzz"
     size:
-      selector: td:nth-child(5)
-    grabs:
       selector: td:nth-child(6)
-    seeders:
+    grabs:
       selector: td:nth-child(7)
-    leechers:
+    seeders:
       selector: td:nth-child(8)
+    leechers:
+      selector: td:nth-child(9)
     downloadvolumefactor:
       case:
         strong.tl_free: 0


### PR DESCRIPTION
### Summary of Changes
Adjusted the `td:nth-child` indexes for `size`, `grabs`, `seeders`, and `leechers` in `definitions/v11/brasiltracker.yml` to match the current HTML layout of the tracker's search page.

### Description
The torrent results table (`#torrent_table > tbody > tr.torrent`) currently includes an **Uploader** column as the 4th `<td>` element. This caused a 1-column offset for all subsequent fields starting from the 5th column (Time/Tempo).

Because of this offset, Prowlarr was attempting to parse:
- **Date/Time** as the file **size**.
- **Size** as **grabs** (snatches).
- **Grabs** as **seeders**.
- **Seeders** as **leechers**.
- **Leechers** were completely omitted (falling off the end of the previous mappings).

#### Column Mapping Comparison:

| Column Name | Actual HTML Column | Previous YAML Selector | Corrected YAML Selector |
| :--- | :--- | :--- | :--- |
| **Cover** | `td:nth-child(1)` | N/A | N/A |
| **Name / Year** | `td:nth-child(2)` | `td.big_info` | `td.big_info` |
| **Files** | `td:nth-child(3)` | `td:nth-child(3)` | `td:nth-child(3)` |
| **Uploader** | `td:nth-child(4)` | N/A (Not parsed) | N/A |
| **Time (Tempo)** | `td:nth-child(5)` | `span.time` (inside `td(5)`) | `span.time` |
| **Size (Tamanho)** | `td:nth-child(6)` | `td:nth-child(5)` *(Wrong)* | `td:nth-child(6)` |
| **Grabs (Snatches)**| `td:nth-child(7)` | `td:nth-child(6)` *(Wrong)* | `td:nth-child(7)` |
| **Seeders** | `td:nth-child(8)` | `td:nth-child(7)` *(Wrong)* | `td:nth-child(8)` |
| **Leechers** | `td:nth-child(9)` | `td:nth-child(8)` *(Wrong)* | `td:nth-child(9)` |
