### PR TITLE
Jackett indexers as of 4e3cfcc1eb6fb9cd5df4bb0bc6fd3d018816e31c [2026…

### DIFF
--- a/definitions/v11/arabicsource-api.yml
+++ b/definitions/v11/arabicsource-api.yml
@@ -17,16 +17,18 @@ caps:
     - {id: 5, cat: TV, desc: "مسلسلات رسوم مدبلجة (Dubbed Animated Series)"}
     - {id: 6, cat: TV, desc: "مسلسلات رسوم مترجمة (Subtitled Animated Series)"}
     - {id: 7, cat: TV, desc: "مسلسلات عربية (Arabic Series)"}
+    - {id: 22, cat: TV, desc: "مسلسلات أجنبية (Foreign Series)"}
     - {id: 8, cat: TV, desc: "مسرحيات (Plays)"}
     - {id: 10, cat: Other, desc: "إسلاميات (Islamic Content)"}
     - {id: 11, cat: Other, desc: "رمضانيات (Ramadan Content)"}
     - {id: 12, cat: Other, desc: "منوعات (Variety)"}
     - {id: 13, cat: Audio, desc: "صوتيات (Audio)"}
     - {id: 14, cat: Movies, desc: "كرتون كلاسيك (Classic Cartoons)"}
-    - {id: 15, cat: Other, desc: "تورنت خام (Raw Torrents)"}
+    - {id: 21, cat: Movies, desc: "أفلام كرتون كلاسيك (Classic Animated Films)"}
     - {id: 20, cat: TV/Documentary, desc: "مسلسلات وثائقيات (Documentary Series)"}
     - {id: 9, cat: Movies, desc: "أفلام وثائقيات (Documentary Films)"}
     - {id: 19, cat: Other, desc: "تورينتات ضائعة (Lost Torrents)"}
+    - {id: 15, cat: Other, desc: "تورنت خام (Raw Torrents)"}
 
   modes:
     search: [q]

--- a/definitions/v11/arabp2p.yml
+++ b/definitions/v11/arabp2p.yml
@@ -161,10 +161,17 @@ search:
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[(\\d{4})\\]\\s*\\[م(\\d+)\\]", "S$3E$1 [$2]"]
         - name: re_replace
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
+        # English bracket forms used by YANGO / SHAHID / TOD packs:
+        #   [E08] [S01] / [E08-E09] [S01]  -> S01E08 / S01E08-E09
+        # [S05] [E02] / [S05] [E02 E03]  -> S05E02 / S05E02 E03
+        - name: re_replace
+          args: ["\\[(E\\d+(?:[\\s-]+E\\d+)?)\\]\\s*\\[(S\\d+)\\]", "$2$1"]
+        - name: re_replace
+          args: ["\\[(S\\d+)\\]\\s*\\[(E\\d+(?:[\\s-]+E\\d+)?)\\]", "$1$2"]
         - name: re_replace
           args: ["^\\[(\\d+(?:[\\s-]+\\d+)*)\\](?!\\s*\\[م)", "S01E$1"]
         - name: re_replace
-          args: ["E(\\d+)[\\s-]+(\\d+)", "E$1-E$2"]
+          args: ["E(\\d+)[\\s-]+(\\d+)\\b", "E$1-E$2"]
         - name: re_replace
           args: ["\\[\\s*\\]", ""]
         - name: re_replace
@@ -187,13 +194,16 @@ search:
       selector: a[href^="magnet:?xt="]
       attribute: href
       optional: true
+    poster:
+      selector: a.screenshot
+      attribute: rel
     date:
       selector: span.upload-date > span
       attribute: title
       # auto adjusted by site account profile
       filters:
         - name: dateparse
-          args: "MM-yy-dd HH:mm:ss tt"
+          args: "yy-MM-dd hh:mm:ss tt"
     size:
       selector: span.size
     seeders:

--- a/definitions/v11/bjshare.yml
+++ b/definitions/v11/bjshare.yml
@@ -1,43 +1,44 @@
 ---
 id: bjshare
-name: Bj-Share
-description: "Private PT-BR torrent"
+name: BJ-Share
+description: "BJ-Share is a BRAZILIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: pt-BR
 type: private
 encoding: UTF-8
 links:
   - https://bj-share.info/
+legacylinks:
+  - https://bj-share.me/
 
 caps:
   categorymappings:
     - {id: 1, cat: Movies, desc: "Filmes"}
-    - {id: 2, cat: TV, desc: "TV"}
+    - {id: 2, cat: TV, desc: "Seriados"}
     - {id: 3, cat: PC, desc: "Aplicativos"}
     - {id: 4, cat: PC/Games, desc: "Jogos"}
     - {id: 5, cat: Books/Comics, desc: "Mangás"}
-    - {id: 6, cat: TV, desc: "Vídeos de TV"}
     - {id: 7, cat: Other, desc: "Outros"}
     - {id: 8, cat: TV/Sport, desc: "Esportes"}
     - {id: 9, cat: Books/Mags, desc: "Revistas"}
-    - {id: 10, cat: Books, desc: "E-Books"}
+    - {id: 10, cat: Books/EBook, desc: "E-Books"}
     - {id: 11, cat: Audio/Audiobook, desc: "Audiobook"}
-    - {id: 12, cat: Books/Comics, desc: "Histórias em Quadrinhos"}
-    - {id: 13, cat: TV, desc: "Stand Up Comedy"}
-    - {id: 14, cat: TV, desc: "TV/Anime"} # Anime format is equal to TV Show (SXXEXX) except old ones like one piece
+    - {id: 12, cat: Books/Comics, desc: "HQs"}
+    - {id: 13, cat: TV/Other, desc: "Stand Up Comedy"}
+    - {id: 14, cat: TV/Anime, desc: "Animes"}
     - {id: 15, cat: XXX/ImageSet, desc: "Fotos Adultas"}
-    - {id: 16, cat: TV/Other, desc: "Desenho Animado"}
-    - {id: 17, cat: TV/Documentary, desc: "Documentários"}
     - {id: 18, cat: Other, desc: "Cursos"}
     - {id: 19, cat: XXX, desc: "Filmes Adultos"}
     - {id: 20, cat: XXX/Other, desc: "Jogos Adultos"}
     - {id: 21, cat: XXX/Other, desc: "Mangás Adultos"}
     - {id: 22, cat: XXX/Other, desc: "Animes Adultos"}
-    - {id: 23, cat: XXX/Other, desc: "HQ Adultos"}
+    - {id: 23, cat: XXX/Other, desc: "HQs Adultas"}
+    - {id: 24, cat: Books/Mags, desc: "Jornais"}
 
   modes:
     search: [q]
-    tv-search: [q, season, ep]
-    movie-search: [q]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
+    book-search: [q]
 
 settings:
   - name: cookie
@@ -45,10 +46,30 @@ settings:
     label: Cookie
   - name: info_cookie
     type: info_cookie
+  - name: info_grouping
+    type: info
+    label: Torrent Grouping
+    default: "<b>Important:</b> You must configure your BJ-Share account to disable torrent grouping. Go to <b>Configurações</b> (Settings) > <b>Agrupamento dos torrents</b> (Torrent grouping), select <b>Desativar</b> (Disable), and click <b>Salvar Configurações</b> (Save Settings)."
   - name: freeleech
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: time
+    options:
+      time: created
+      seeders: seeders
+      size: size
+      name: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
 
 login:
   method: cookie
@@ -59,139 +80,103 @@ login:
     selector: a[href^="/logout.php?auth="]
 
 search:
-  # https://bj-share.info/torrents.php?searchstr=aves+de+rapina&filter_cat%5B1%5D=1
   paths:
     - path: torrents.php
-
+      followredirect: true
   inputs:
     $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
-    searchstr: "{{ .Keywords }}"
+    searchstr: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
+    order_by: "{{ .Config.sort }}"
+    order_way: "{{ .Config.type }}"
     freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
+    action: basic
+    searchsubmit: 1
 
   keywordsfilters:
     - name: re_replace
-      args: ["(S[0-9]+E[0-9]+|S[0-9]+)", ""] # remove SXXEXX or SXX from search
+      args: ["(?i)\\b(?:[SE]\\d{1,4}){1,2}\\b\\s?", ""] # remove SXXEXX or SXX from search
 
   rows:
-    # If the category is a TV show/Anime, there's a necessity to filter the results by season/episode to not show all of them
-    selector: "table.torrent_table > tbody > tr:not(tr.colhead).group,
-              table.torrent_table tbody tr:not(tr.colhead):contains('{{ .Query.Episode }}')"
-    filters:
-      - name: andmatch
+    selector: "tr.torrent, tr.group_torrent:not(.season_header)"
 
   fields:
-    download:
-      selector: a[title="Baixar"]
+    category_raw:
+      selector: a[href*="filter_cat"]
       attribute: href
-
-    _singleTorrentInfo:
-      selector: div.torrent_info
-
-    _multipleTorrentInfo:
-      selector: a[href^="torrents.php?id="]
-
-    _info: # example [MKV / x265 / WEB-DL / Legendado / 4K / Free]
-      text: "{{ if .Result._singleTorrentInfo }}{{.Result._singleTorrentInfo}}{{ else }}{{.Result._multipleTorrentInfo}}{{ end }}"
-      filters:
-        - name: replace
-          args: ["Full HD", "1080p"]
-        - name: replace
-          args: ["4K", "2160p"]
-        - name: replace
-          args: ["SD", "480p"]
-        - name: replace
-          args: ["/ HD]", "720p"]
-        - name: replace
-          args: ["/ HD /", "720p"]
-        - name: replace
-          args: ["/ Free", ""]
-        - name: re_replace
-          args: ["[\\[\\]]+", ""]
-
-    _rawTitle:
-      selector: div.group_info
-      filters:
-        - name: re_replace
-          args: ["(\n.*)", ""] # remove everything after newline
-        - name: re_replace
-          args: ["  |\t", ""] # remove double space and tabs
-
-    _year:
-      text: "{{ .Result._rawTitle }}"
+      optional: true
       filters:
         - name: regexp
-          args: "\\[([0-9]*)\\]"
-
-    details:
-      selector: a[href^="torrents.php?id="]:not(.tooltip)
-      attribute: href
-
-    title_MovieTV: # Movie and TV Format
-      # Title defined as:
-        # PT-BR/Japanese title [en-US title] [year]
-      text: "{{ .Result._rawTitle }}"
-      filters:
-        - name: re_replace
-          args: ["\\[[0-9]*\\].*", ""] # Removes the year and everything after
-        - name: re_replace
-          args: ["(.*)\\[(!?[^/]*?)\\]", "$2"]   # Parse only en-us title, when available
-        - name: append
-          args: "{{ .Result._year }}"
-        - name: append
-          args: " {{ .Result._info }}"
-
-    title_Other:
-      # Only remove brackets
-      text: "{{ .Result._rawTitle }}"
-      filters:
-        - name: re_replace
-          args: ["\\[|\\]", " "] # Remove Brackets
-
-    title_details:
-      # Title defined as:
-        # PT-BR/Japanese title [en-US title] [year]
-      text: "{{ .Result._rawTitle }}"
-      filters:
-        - name: re_replace
-          args: ["\\[[0-9]*\\].*", ""] # Removes the year and everything after
-        - name: re_replace
-          args: ["(.*)\\[(!?[^/]*?)\\]", "$2"]   # Parse only en-us title, when available
-
+          args: '(?i)filter_cat(?:\[|%5b|%5B)(\d+)(?:\]|%5d|%5D)'
     category_details:
-      selector: td.cats_col > a
+      selector: ":root td:contains('Categoria:') + td a[href*='filter_cat']"
       attribute: href
+      optional: true
       filters:
         - name: regexp
-          args: "%5b(\\d+?)%5d"
-
+          args: '(?i)filter_cat(?:\[|%5b|%5B)(\d+)(?:\]|%5d|%5D)'
     category:
-      text: "{{ .Result.category_details }}"
-
+      text: "{{ if .Result.category_raw }}{{ .Result.category_raw }}{{ else }}{{ .Result.category_details }}{{ end }}"
+    title_group:
+      attribute: data-torrentname
+      optional: true
+    title_search:
+      selector: div.torrent_info[data-torrentname]
+      attribute: data-torrentname
+      optional: true
     title:
-      text: "{{ if
-                    or (eq .Result.category_details \"1\")
-                   (or (eq .Result.category_details \"2\")  (or (eq .Result.category_details \"14\")
-                   (or (eq .Result.category_details \"16\") (or (eq .Result.category_details \"17\")
-                   (or eq .Result.category_details \"8\")
-                   (or (eq .Result.category_details \"13\") (eq .Result.category_details \"6\")))))))
-             }}{{.Result.title_MovieTV}}{{ else }}{{.Result.title_Other}}{{ end }}"
-
+      text: "{{ if .Result.title_search }}{{ .Result.title_search }}{{ else }}{{ .Result.title_group }}{{ end }}"
+    imdbid_raw:
+      selector: div.torrent_info[data-imdbid]
+      attribute: data-imdbid
+      optional: true
+    imdbid_global:
+      selector: ":root a[href*='imdb.com/title/tt']"
+      attribute: href
+      optional: true
+    imdbid:
+      text: "{{ if .Result.imdbid_raw }}{{ .Result.imdbid_raw }}{{ else }}{{ .Result.imdbid_global }}{{ end }}"
+    poster:
+      selector: div.group_image img
+      attribute: src
+    description_search:
+      selector: div.torrent_info
+      optional: true
+    description_group:
+      selector: a[href*="torrentid="]:not([title])
+      optional: true
+    description:
+      text: "{{ if .Result.description_search }}{{ .Result.description_search }}{{ else }}{{ .Result.description_group }}{{ end }}"
+    details:
+      selector: a[href^="torrents.php?id="], a[href^="torrents.php?torrentid="], a[href^="series.php?id="]
+      attribute: href
+    download:
+      selector: a[href^="torrents.php?action=download"]
+      attribute: href
     size:
       selector: td:nth-last-child(4)
-    grabs:
-      selector: td:nth-last-child(3)
     seeders:
       selector: td:nth-last-child(2)
     leechers:
       selector: td:nth-last-child(1)
+    grabs:
+      selector: td:nth-last-child(3)
+    date_raw:
+      selector: span.time.bjtooltip
+      attribute: title
+      optional: true # Date is not available in the group torrents page
+      filters:
+        - name: append
+          args: " -03:00" # BJ-Share time is UTC-3
+        - name: dateparse
+          args: "MMM dd yyyy, HH:mm zzz"
+    date:
+      text: "{{ if .Result.date_raw }}{{ .Result.date_raw }}{{ else }}now{{ end }}"
     downloadvolumefactor:
       case:
-        strong[title*="Free"]: 0
+        "strong.free": 0
         "*": 1
     uploadvolumefactor:
       text: 1
     minimumratio:
       text: 1.0
-    minimumseedtime:
-      # 7 days (as seconds = 7 x 24 x 60 x 60)
-      text: 604800
+# engine n/a

--- a/definitions/v11/funzone-api.yml
+++ b/definitions/v11/funzone-api.yml
@@ -10,24 +10,28 @@ links:
 
 caps:
   categorymappings:
-    - {id: 3, cat: Movies/HD, desc: "Filme HD-RO"}
+    - {id: 3, cat: Movies/HD, desc: "Movies HD-RO"}
     - {id: 2, cat: TV, desc: "TV"}
-    - {id: 1, cat: Movies, desc: "Filme HD"}
-    - {id: 4, cat: PC/Games, desc: "Jocuri PC"}
-    - {id: 5, cat: Audio, desc: "Muzica"}
-    - {id: 23, cat: Movies/UHD, desc: "Filme UHD-RO"}
+    - {id: 1, cat: Movies, desc: "Movies HD"}
+    - {id: 4, cat: PC/Games, desc: "Games PC"}
+    - {id: 5, cat: Audio, desc: "Music"}
+    - {id: 23, cat: Movies/UHD, desc: "Movies UHD-RO"}
     - {id: 6, cat: PC, desc: "Software"}
     - {id: 7, cat: TV/Anime, desc: "Anime"}
-    - {id: 8, cat: TV/Documentary, desc: "Documentare"}
+    - {id: 8, cat: TV/Documentary, desc: "Documentaries"}
     - {id: 9, cat: TV/Sport, desc: "Sport"}
-    - {id: 10, cat: Console, desc: "Jocuri Console"}
-    - {id: 11, cat: Movies, desc: "Filme Romanesti"}
-    - {id: 12, cat: Movies/Other, desc: "Desene"}
+    - {id: 10, cat: Console, desc: "Games Console"}
+    - {id: 11, cat: Movies, desc: "Movies Romanian"}
+    - {id: 12, cat: Movies/Other, desc: "Cartoons"}
     - {id: 17, cat: XXX, desc: "XXX"}
-    - {id: 18, cat: PC/Games, desc: "Jocuri Classic"}
-    - {id: 19, cat: Audio/Video, desc: "Videoclipuri"}
-    - {id: 20, cat: Movies/SD, desc: "Filme SD-RO"}
+    - {id: 18, cat: PC/Games, desc: "Classic Games"}
+    - {id: 24, cat: Audio, desc: "Music/Packs"}
+    - {id: 19, cat: Audio/Video, desc: "Videos"}
+    - {id: 25, cat: TV, desc: "TV/Packs"}
+    - {id: 20, cat: Movies/SD, desc: "Movies SD-RO"}
+    - {id: 27, cat: Other, desc: "Pics/Wallpapers"}
     - {id: 21, cat: Books, desc: "EBooks"}
+    - {id: 28, cat: PC, desc: "Software/Packs"}
     - {id: 22, cat: Movies, desc: "Classic Movies"}
 
   modes:

--- a/definitions/v11/hdzero.yml
+++ b/definitions/v11/hdzero.yml
@@ -119,8 +119,6 @@ search:
       selector: details_link
     download:
       selector: download_link
-    infohash:
-      selector: info_hash
     poster:
       selector: meta.poster
       filters:
@@ -190,4 +188,4 @@ search:
     minimumseedtime:
       # 5 days (as seconds = 5 x 24 x 60 x 60)
       text: 432000
-# json UNIT3D 9.1.5 (custom)
+# json UNIT3D 9.2.0 (custom)

--- a/definitions/v11/punkshorror.yml
+++ b/definitions/v11/punkshorror.yml
@@ -4,7 +4,7 @@ name: Punk's Horror Tracker
 description: "Punk's Horror Tracker is a HUNGARIAN Private Tracker for Horror MOVIES / TV"
 language: hu-HU
 type: private
-encoding: ISO-8859-2
+encoding: UTF-8
 links:
   - https://punck-tracker.net/
 
@@ -24,8 +24,8 @@ caps:
     - {id: 85, cat: Movies, desc: "Mystery-Fantasy Hun"}
     - {id: 83, cat: Movies, desc: "Punk Release"}
     - {id: 76, cat: Movies, desc: "Retro Film"}
-    - {id: 70, cat: Movies, desc: "Scfi Eng"}
-    - {id: 69, cat: Movies, desc: "Scfi Hun"}
+    - {id: 70, cat: Movies, desc: "Scifi Eng"}
+    - {id: 69, cat: Movies, desc: "Scifi Hun"}
     - {id: 75, cat: TV, desc: "Sorozat Eng"}
     - {id: 74, cat: TV, desc: "Sorozat Hun"}
     - {id: 100, cat: Movies, desc: "THC Release"}
@@ -48,13 +48,14 @@ settings:
     label: Password
   - name: freeleech
     type: checkbox
-    label: Search FreeLeech only
+    label: Filter freeleech only
     default: false
   - name: sort
     type: select
     label: Sort requested from site
     default: 4
     options:
+      1: title
       4: added
       5: size
       7: seeders
@@ -72,34 +73,30 @@ settings:
 
 login:
   path: login.php
-  method: form
-  form: form[action="takelogin.php"]
+  method: post
   inputs:
     username: "{{ .Config.username }}"
     password: "{{ .Config.password }}"
   error:
-    - selector: "td:contains(\"Belépési hiba\")"
+    - selector: "tr table:contains(\"Hiba\")"
   test:
     path: index.php
-    selector: a[href="logout.php"]
+    selector: a[href^="logout.php"]
 
 search:
   paths:
     - path: browse.php
   inputs:
     $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
-    onlyname: 1
     search: "{{ .Keywords }}"
-    # 0 active, 1 all, 2 deadonly, 3 freeleech
-    incldead: "{{ if .Config.freeleech }}3{{ else }}1{{ end }}"
+    # 0 active, 1 all, 2 deadonly, 3 uploaded, 4 waitingforseed
+    incldead: 1
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
     # does not support imdbid searches
 
   rows:
-    selector: table.alap99 > tbody#linkhatter > tr
-    filters:
-      - name: andmatch
+    selector: "table table table > tbody > tr:has(a[href^=\"details.php?id=\"]){{ if .Config.freeleech }}:has(td:nth-last-child(4) span:nth-of-type(1):contains(\"0\")){{ else }}{{ end }}"
 
   fields:
     category:
@@ -121,49 +118,39 @@ search:
       selector: a[href^="details.php?id="]
       attribute: href
     download:
-      selector: a[href^="download.php?id="]
+      selector: a[href^="download.php?torrent="]
       attribute: href
     imdbid:
       selector: a[href*="imdb.com/title/tt"]
       attribute: href
     date:
-      selector: td:nth-child(2) > b > font
+      selector: td:nth-last-child(5)
       filters:
-        - name: replace
-          args: ["\xA0", ""]
-        - name: replace
-          args: ["Feltöltve:", ""]
         - name: append
           args: " +01:00" # CET
         - name: dateparse
-          args: "yyyy-MM-ddHH:mm:ss zzz"
+          args: "yyyy-MM-dd HH:mm:ss zzz"
     poster:
-      selector: a[onmouseover]
-      attribute: onmouseover
-      filters:
-        - name: regexp
-          args: src=([^\s]+)
+      selector: a.preview
+      attribute: href
     size:
-      selector: td:nth-child(7)
+      selector: td:nth-last-child(4) b
+    files:
+      selector: td:nth-last-child(7)
     grabs:
-      selector: td:nth-last-child(4)
-    seeders:
       selector: td:nth-last-child(3)
-    leechers:
+    seeders:
       selector: td:nth-last-child(2)
+    leechers:
+      selector: td:nth-last-child(1)
     description:
       case:
         img[src="pic/yes.png"]: Verified
         img[src="pic/nincs.png"]: Unverified
     downloadvolumefactor:
-      case:
-        img[src="pic/golden.gif"]: 0
-        "*": 1
+      selector: td:nth-last-child(4) span:nth-of-type(1)
     uploadvolumefactor:
-      selector: td:nth-child(7) > center > b > font
-      filters:
-        - name: regexp
-          args: (\d+)
+      selector: td:nth-last-child(4) span:nth-of-type(2)
     minimumratio:
       text: 0.8
     minimumseedtime:

--- a/definitions/v11/rotorrent-api.yml
+++ b/definitions/v11/rotorrent-api.yml
@@ -183,7 +183,9 @@ search:
         True: 2 # double
     uploadvolumefactor:
       text: "{{ if .Result._featured }}2{{ else }}{{ .Result.uploadvolumefactor_double_upload }}{{ end }}"
+    minimumratio:
+      text: 1.0
     minimumseedtime:
-      # 7 days (as seconds = 7 x 24 x 60 x 60)
-      text: 604800
+      # 3 days (as seconds = 3 x 24 x 60 x 60)
+      text: 259200
 # json UNIT3D 9.2.0

--- a/definitions/v11/torrentsome.yml
+++ b/definitions/v11/torrentsome.yml
@@ -9,9 +9,8 @@ followredirect: true
 requestDelay: 2
 # to fetch current domain use https://tzip.top/
 links:
-  - https://torrentsome245.com/
+  - https://torrentsome246.com/
 legacylinks:
-  - https://torrentsome230.com/
   - https://torrentsome231.com/
   - https://torrentsome232.com/
   - https://torrentsome233.com/
@@ -26,6 +25,7 @@ legacylinks:
   - https://torrentsome242.com/
   - https://torrentsome243.com/
   - https://torrentsome244.com/
+  - https://torrentsome245.com/
 
 caps:
   categorymappings:

--- a/definitions/v11/torrenttip.yml
+++ b/definitions/v11/torrenttip.yml
@@ -9,9 +9,8 @@ followredirect: true
 requestDelay: 2
 # to fetch current domain use https://tzip.top/
 links:
-  - https://torrenttip226.top/
+  - https://torrenttip227.top/
 legacylinks:
-  - https://torrenttip211.top/
   - https://torrenttip212.top/
   - https://torrenttip213.top/
   - https://torrenttip214.top/
@@ -26,6 +25,7 @@ legacylinks:
   - https://torrenttip223.top/
   - https://torrenttip224.top/
   - https://torrenttip225.top/
+  - https://torrenttip226.top/
 
 caps:
   categorymappings:

--- a/definitions/v11/uztracker.yml
+++ b/definitions/v11/uztracker.yml
@@ -149,7 +149,7 @@ caps:
     - {id: 236, cat: Audio/Lossless, desc: " |- ♫ Джаз и Блюз	Hi-Res"}
     - {id: 324, cat: Audio, desc: "Оцифровки с аналоговых носителей"}
     - {id: 330, cat: Audio, desc: " |- ♫ Зарубежная поп музыка (оцифровки)"}
-    - {id: 328, cat: Audio, desc: " |- ♫ Советская и Российская эстрада (оцифровки)"}
+    - {id: 466, cat: Audio, desc: " |- Советская и Российская эстрада (оцифровки)"}
     - {id: 453, cat: Audio, desc: " |- ♫ Шансон и авторская песня (оцифровки"}
     - {id: 455, cat: Audio, desc: " |- ♫ Зарубежный и Отечественный Metal (оцифровки)"}
     - {id: 331, cat: Audio, desc: " |- ♫ Русский рок (оцифровки)"}
@@ -174,6 +174,17 @@ caps:
     - {id: 294, cat: Audio/Video, desc: " |- Музыкальные шоу"}
     - {id: 158, cat: Audio/Video, desc: " |- Другие направления"}
     # Литература # Literature
+    - {id: 167, cat: Audio/Audiobook, desc: "Аудиокниги"}
+    - {id: 464, cat: Audio/Audiobook, desc: " |- ♫ История"}
+    - {id: 335, cat: Audio/Audiobook, desc: " |- ♫ Русская литература ХХ-ХХI века"}
+    - {id: 232, cat: Audio/Audiobook, desc: " |- ♫ Детективы, приключения, триллеры"}
+    - {id: 337, cat: Audio/Audiobook, desc: " |- ♫ Детективы  Дарьи Донцовой"}
+    - {id: 210, cat: Audio/Audiobook, desc: " |- ♫ Зарубежные авторы. Романы, повести, рассказы"}
+    - {id: 233, cat: Audio/Audiobook, desc: " |- ♫ Любовные романы"}
+    - {id: 176, cat: Audio/Audiobook, desc: " |- ♫ Мистика, фантастика, ужасы"}
+    - {id: 175, cat: Audio/Audiobook, desc: " |- ♫ Любовно-фантастический роман"}
+    - {id: 174, cat: Audio/Audiobook, desc: " |- Аудиокниги на других языках (Audio)"}
+    - {id: 319, cat: Audio/Audiobook, desc: " |- Аудиокниги для детей"}
     - {id: 166, cat: Books, desc: "Книги FB2"}
     - {id: 173, cat: Books, desc: " |- Художественная литература"}
     - {id: 314, cat: Books, desc: " |- Учебно-техническая литература"}
@@ -187,17 +198,6 @@ caps:
     - {id: 440, cat: Books/Mags, desc: " |- Космос"}
     - {id: 439, cat: Books/Mags, desc: " |- История"}
     - {id: 438, cat: Books/Mags, desc: " |- Хобби"}
-    - {id: 167, cat: Audio/Audiobook, desc: "Аудиокниги"}
-    - {id: 464, cat: Audio/Audiobook, desc: " |- ♫ История"}
-    - {id: 335, cat: Audio/Audiobook, desc: " |- ♫ Русская литература ХХ-ХХI века"}
-    - {id: 232, cat: Audio/Audiobook, desc: " |- ♫ Детективы, приключения, триллеры"}
-    - {id: 337, cat: Audio/Audiobook, desc: " |- ♫ Детективы  Дарьи Донцовой"}
-    - {id: 210, cat: Audio/Audiobook, desc: " |- ♫ Зарубежные авторы. Романы, повести, рассказы"}
-    - {id: 233, cat: Audio/Audiobook, desc: " |- ♫ Любовные романы"}
-    - {id: 176, cat: Audio/Audiobook, desc: " |- ♫ Мистика, фантастика, ужасы"}
-    - {id: 175, cat: Audio/Audiobook, desc: " |- ♫ Любовно-фантастический роман"}
-    - {id: 174, cat: Audio/Audiobook, desc: " |- Аудиокниги на других языках (Audio)"}
-    - {id: 319, cat: Audio/Audiobook, desc: " |- Аудиокниги для детей"}
     - {id: 350, cat: Books, desc: "Медицина и здоровье"}
     - {id: 351, cat: Books, desc: " |- Клиническая медицина до 1980 года"}
     - {id: 352, cat: Books, desc: " |- Клиническая медицина с 1980 по 2000 год"}


### PR DESCRIPTION
Modified Indexers:
definitions/v11/arabicsource-api.yml
definitions/v11/arabp2p.yml
definitions/v11/bjshare.yml
definitions/v11/funzone-api.yml
definitions/v11/hdzero.yml
definitions/v11/punkshorror.yml
definitions/v11/rotorrent-api.yml
definitions/v11/torrentsome.yml
definitions/v11/torrenttip.yml
definitions/v11/uztracker.yml

This brings bjshare in line with the new yml version from jackett, previously they were using C#

Closes #914 