### PR TITLE
RuTor: add xrutor.org and new-rutor.org mirrors

### DIFF
--- a/definitions/v11/rutor.yml
+++ b/definitions/v11/rutor.yml
@@ -8,10 +8,10 @@ encoding: UTF-8
 links:
   - https://xrutor.org/
   - https://new-rutor.org/
-  - https://rutor.info/
-  - https://rutor.is/
   - http://6tor.org/ # IPv6-only
 legacylinks:
+  - https://rutor.info/
+  - https://rutor.is/
   - https://rutor.uk-unblock.xyz/
   - https://rutor.ind-unblock.xyz/
   - https://rutor.unblocked.bar/
@@ -65,13 +65,6 @@ settings:
       9: "title asc"
   - name: info_category_8000
     type: info_category_8000
-
-download:
-  selectors:
-    - selector: a[href^="/inc/download/file/"]
-      attribute: href
-    - selector: a[href^="magnet:?xt="]
-      attribute: href
 
 search:
   paths:

--- a/definitions/v11/rutor.yml
+++ b/definitions/v11/rutor.yml
@@ -6,6 +6,8 @@ language: ru-RU
 type: public
 encoding: UTF-8
 links:
+  - https://xrutor.org/
+  - https://new-rutor.org/
   - https://rutor.info/
   - https://rutor.is/
   - http://6tor.org/ # IPv6-only
@@ -20,7 +22,7 @@ legacylinks:
   - https://rutor.unblocked.monster/
   - https://rutor.mrunblock.bond/ # for magnet only
   - https://rutor.nocensor.cloud/
-  - http://new-rutor.org/ # Oops. Something went wrong, try reloading the page
+  - http://new-rutor.org/
   - http://rutor.info/
   - http://rutor.is/
 
@@ -63,6 +65,13 @@ settings:
       9: "title asc"
   - name: info_category_8000
     type: info_category_8000
+
+download:
+  selectors:
+    - selector: a[href^="/inc/download/file/"]
+      attribute: href
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:


### PR DESCRIPTION
## Summary
- Add `https://xrutor.org/` and `https://new-rutor.org/` as active RuTor mirrors (listed first for failover when older domains are blocked in RU)
- Move `http://new-rutor.org/` to legacylinks without the stale error comment

RuTor site banner now recommends these mirrors after Roskomnadzor blocks; `new-rutor.org` is blocked in RU while `xrutor.org` remains reachable.

## Test plan
- [x] Validated `definitions/v11/rutor.yml` against v11 schema
- [x] Verified both mirror homepages return torrent rows with magnet links
- [x] Prowlarr indexer test passed for `https://xrutor.org/` and `https://new-rutor.org/`
