### PR TITLE
Add 'created' option to sort in mma-torrents.yml

### DIFF
--- a/definitions/v11/mma-torrents.yml
+++ b/definitions/v11/mma-torrents.yml
@@ -83,6 +83,7 @@ settings:
     label: Sort requested from site
     default: seeders
     options:
+      created: added
       name: title
       size: size
       seeders: seeders


### PR DESCRIPTION
#### Indexer/Tracker
MMA-Torrents.com

#### Description
Allow sorting by `added` param, 'Minimum Seeders' gives us *some* control over seeder filtering. This enables tools like autobrr to grab the newest freeleech metadata to try and be early in the swarm. Without sorting by newest, you get old freeleech metadata, with a sprinkle of new here or there; this sorting fixes that.


#### Issues Fixed or Closed by this PR
