### PR TITLE
Additional category mapping

### DIFF
--- a/definitions/v11/torrenthr.yml
+++ b/definitions/v11/torrenthr.yml
@@ -13,6 +13,7 @@ caps:
     - {id: 31, cat: TV/Anime, desc: "Anime"}
     - {id: 4, cat: Movies/SD, desc: "Filmovi/SD"}
     - {id: 18, cat: Movies/Foreign, desc: "Crtani Filmovi"}
+    - {id: 18, cat: TV/Foreign, desc: "Crtani Filmovi"}
     - {id: 5, cat: PC/Games, desc: "Igre/PC"}
     - {id: 7, cat: TV/SD, desc: "Serije/SD"}
     - {id: 1, cat: PC/0day, desc: "Aplikacije"}


### PR DESCRIPTION
#### Indexer/Tracker
Additional category mapping for TorrentHR

#### Description
Added duplicate mapping for category 18 "Crtani filmovi" for TV/Foreign category since this category on the tracker includes both animated movies and animated TV shows.