### PR TITLE
Add back UA for gay-torrents

### DIFF
--- a/definitions/v11/gay-torrents.yml
+++ b/definitions/v11/gay-torrents.yml
@@ -141,7 +141,7 @@ search:
       args: ["(\\w+)", "+$1"] # prepend + to each word
 
   headers:
-    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.1901.203"]
+    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.1901.203"] # Prowlarr-specific, do not remove. 
     Referer: ["{{ .Config.sitelink }}"]
 
   rows:

--- a/definitions/v11/gay-torrents.yml
+++ b/definitions/v11/gay-torrents.yml
@@ -141,6 +141,7 @@ search:
       args: ["(\\w+)", "+$1"] # prepend + to each word
 
   headers:
+    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.1901.203"]
     Referer: ["{{ .Config.sitelink }}"]
 
   rows:


### PR DESCRIPTION
#### Indexer/Tracker
gay-torrents

#### Description
Adds back the User Agent that was removed in 2031fef5f100790f44070857dd43b5402576c0bd

Refer to #370 where this was called out as a difference between Jackett and Prowlarr, but got removed in February and has been broken since then.

I've tested this locally and it works again once UA is added.

#### Issues Fixed or Closed by this PR

N/A