### PR TITLE
Update 1337x links to latest

### DIFF
--- a/definitions/v11/1337x.yml
+++ b/definitions/v11/1337x.yml
@@ -9,10 +9,12 @@ requestDelay: 3
 # get status and news on domains at the official site https://1337x-status.org/
 links:
   - https://1337x.to/
-  - https://1337x.st/
-  - https://x1337x.ws/
-  - https://x1337x.eu/
-  - https://x1337x.cc/
+  - https://1337x.tw/
+  - https://1337xto.to/
+  - https://1337xx.to/
+  - https://1337xxx.to/
+  - https://1337x.is/
+  - https://13377x.tw/
 legacylinks:
   - https://1337x.is/
   - https://1337x.gd/


### PR DESCRIPTION
#### Indexer/Tracker
1337x

#### Description
Some 1337x links are stale or expired domains. Updated to reflect current list provided in their /about page here: https://www.1337x.to/about

#### Issues Fixed or Closed by this PR

Removes and updates stale, non-functional links