### PR TITLE
Close issues that don't follow issue templates

### DIFF
--- a/.github/workflows/close_invalid_issues.yml
+++ b/.github/workflows/close_invalid_issues.yml
@@ -1,0 +1,26 @@
+name: Close issues without labels
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+      - name: Close issue if no labels found
+        if: join(github.event.issue.labels) == ''
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body ":wave: @${{ github.event.issue.user.login }}, this issue was closed automatically because it was created without following an issue template. Please update the issue following the correct template for this issue. Once updated please reply to this issue so we can review and re-open. In the future, use the [issue templates](https://github.com/${{ github.repository }}/issues/new/choose) instead of creating your own."
+          gh issue close ${{ github.event.issue.number }} --reason "not planned"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
#### Indexer/Tracker

n/a

#### Description

Add workflow to close issues created without the a template
Cherry-picked from https://github.com/Sonarr/Sonarr/commit/c8f15ae1989cfb7d83cc580409a972e9fdd44a7c

#### Issues Fixed or Closed by this PR
