### PR TITLE
C411: add requestDelay to stay within the tracker rate limit

### DIFF
--- a/definitions/v11/c411.yml
+++ b/definitions/v11/c411.yml
@@ -5,6 +5,7 @@ description: "C411 (Community 411) is a FRENCH Private Torrent Tracker for MOVIE
 language: fr-FR
 type: private
 encoding: UTF-8
+requestDelay: 5 # rate limit: 15 requests per minute
 links:
   - https://c411.org/
 legacylinks:


### PR DESCRIPTION
#### Indexer/Tracker

C411

#### Description

The C411 definition declares no `requestDelay`, so Prowlarr falls back to its default request spacing (~2s, i.e. ~30 req/min). The tracker's own limit is lower, and it starts replying `429 TooManyRequests` with a `Retry-After` of 25 seconds.

Measured over 28 rate-limit events in Prowlarr logs (v2.5.2.5491), counting outbound requests per minute:

| requests / min | result |
| --- | --- |
| up to 17 | sometimes accepted |
| from 14 | `429 TooManyRequests` |

Peak hourly volume was 138 requests, so the tracker is not limiting on total volume — only on burst rate. The ceiling sits at roughly 15 requests per minute.

`requestDelay: 5` keeps Prowlarr at 12 req/min, comfortably under that ceiling. This mirrors what several other definitions already do — for example `tr4ker.yml` carries `requestDelay: 1 # 60 request per minute`, and that tracker never rate-limits in the same setup.

Log sample:

```
Warn|Cardigann|HTTP Error - Res: HTTP/2.0 [GET] https://c411.org/api/torznab?apikey=(removed)&t=tvsearch&q=...&limit=100: 429.TooManyRequests (115 bytes)
Warn|Cardigann|Request Limit reached for C411. Disabled for 00:00:25
```

#### Issues Fixed or Closed by this PR

None — no existing issue for this.
