### PR TITLE
brasiltracker: strip season & ep from search

### DIFF
--- a/definitions/v11/brasiltracker.yml
+++ b/definitions/v11/brasiltracker.yml
@@ -81,6 +81,11 @@ search:
     freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
     searchsubmit: 1
 
+  keywordsfilters:
+    # strip season and/or ep
+    - name: re_replace
+      args: ["(?i)\\b(?:[SE]\\d{1,4}){1,2}\\b\\s?", ""]
+
   rows:
     selector: table#torrent_table > tbody > tr.torrent
 


### PR DESCRIPTION
#### Indexer/Tracker
brasiltracker

#### Description
brasiltracker.yml is unique to Prowlarr, hence the change being made here

SxxExx is also stripped from Jackett's C# indexer - https://github.com/Jackett/Jackett/blob/2819413dec5e7481d281ef9522bf1ce320f68df9/src/Jackett.Common/Indexers/Definitions/BrasilTracker.cs#L124-L130

#### Issues Fixed or Closed by this PR

* Fixes #1012