### PR TITLE
dreadvault: fix API key help text naming Blutopia

### DIFF
--- a/definitions/v11/dreadvault-api.yml
+++ b/definitions/v11/dreadvault-api.yml
@@ -25,7 +25,7 @@ settings:
   - name: info_key
     type: info
     label: About your API key
-    default: "Find or Generate a new API Token by accessing your <a href=\"https://dreadvault.org/\" target=\"_blank\">Blutopia</a> account <i>My Settings</i> page and clicking on the <b>API Key</b> tab."
+    default: "Find or Generate a new API Token by accessing your <a href=\"https://dreadvault.org/\" target=\"_blank\">DreadVault</a> account <i>My Settings</i> page and clicking on the <b>API Key</b> tab."
   - name: freeleech
     type: checkbox
     label: Search freeleech only


### PR DESCRIPTION
The API key help text says "Blutopia" (copied from the blutopia definition); the link already points to dreadvault.org. Text now says DreadVault.