### PR TITLE
fix(rustorka): use windows-1251 encoding

### DIFF
--- a/definitions/v11/rustorka.yml
+++ b/definitions/v11/rustorka.yml
@@ -4,7 +4,7 @@ name: Rustorka
 description: "Rustorka is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: ru-RU
 type: semi-private
-encoding: UTF-8
+encoding: windows-1251
 links:
   - https://rustorka.com/
 legacylinks:


### PR DESCRIPTION
The Rustorka forum serves `Content-Type: text/html; charset=windows-1251`, but the definition declares `encoding: UTF-8`. This breaks the indexer in two ways at once:

1. **Titles come back as mojibake** — cp1251 bytes are decoded as UTF-8.
2. **Search silently stops filtering.** The query is sent UTF-8-encoded, the site decodes it as cp1251, matches nothing, and returns the front-page listing instead. Every query therefore yields the same set of unrelated releases, which looks like "the indexer works but returns garbage" rather than an error.

### Verification

Same session cookie, same endpoint `forum/tracker.php?nm=…&f[]=-1`, query «Фарго»:

| query encoding | response | occurrences of the term in body |
|---|---|---|
| `%D4%E0%F0%E3%EE` (windows-1251) | 200, 25 topics | **26** |
| `%D0%A4%D0%B0%D1%80%D0%B3%D0%BE` (UTF-8) | 200, 26 topics | **0** |

Header of the page the definition actually uses:

```
$ curl -sI https://rustorka.com/forum/index.php | grep -i content-type
Content-Type: text/html; charset=windows-1251
```

Note for anyone re-checking: the landing page `https://rustorka.com/` does serve UTF-8. Only `forum/` — the path used by `search.paths` — is cp1251, so probing the site root gives a misleading result.

Tested against a live semi-private account; after the change titles render correctly and search returns matching releases.
